### PR TITLE
Fix host limit check for cases when some hosts are unreachable

### DIFF
--- a/playbooks/tasks/host-limit-check.yml
+++ b/playbooks/tasks/host-limit-check.yml
@@ -4,7 +4,16 @@
 - name: Fail if you are targeting more then max_hosts
   vars:
     # Get number of hosts that the running playbook targets
-    num_hosts: "{{ ansible_play_hosts | length }}"
+    num_hosts: "{{ ansible_play_hosts_all | length }}"
   fail:
-    msg: "You are executing the playbook on {{ num_hosts }} hosts\nwhich is more than maximum allowed {{ max_hosts }} hosts for this playbook.\nE.g. you can't target all dev and prod webportals at once.\nUse: ... --limit host1,host2"
+    msg: |
+      You are executing the playbook on {{ num_hosts }} hosts
+      which is more than maximum allowed {{ max_hosts }} hosts for this playbook.
+      
+      E.g. you can't target all dev and prod webportals at once in some playbooks.
+      
+      Use '--limit' command line flag, e.g.:
+      
+          ... --limit host1,host2
+          ... --limit group1,group2
   when: num_hosts | int > max_hosts | int


### PR DESCRIPTION
Main update:
`ansible_play_hosts` was changed to `ansible_play_hosts_all`,
otherwise host limit check doesn't stop the playbook if some hosts are unreachable.