### PR TITLE
Move waiting for nginx restarting check later

### DIFF
--- a/playbooks/tasks/portal-docker-services-start.yml
+++ b/playbooks/tasks/portal-docker-services-start.yml
@@ -65,10 +65,6 @@
     # TODO: Build in parallel, when Ansible support is added
   become: True
   become_user: "user"
-    
-# Confirm all Docker Services Started Up
-- name: Wait Until Docker Services Have Started Up
-  include_tasks: tasks/portal-wait-for-docker-services.yml
 
 # Wait until Sia finished full setup
 - name: Wait until Sia finished full setup
@@ -87,6 +83,10 @@
   ansible.builtin.command: docker system prune --force
   async: "{{ docker_prune_timeout_secs }}"
   poll: 5
+
+# Confirm all Docker Services Started Up
+- name: Wait Until Docker Services Have Started Up
+  include_tasks: tasks/portal-wait-for-docker-services.yml
 
 # Sleep 30 seconds
 - name: Sleep for 30 seconds and continue with play

--- a/playbooks/tasks/portal-docker-services-start.yml
+++ b/playbooks/tasks/portal-docker-services-start.yml
@@ -66,6 +66,12 @@
   become: True
   become_user: "user"
 
+# Prune docker
+- name: Prune docker
+  ansible.builtin.command: docker system prune --force
+  async: "{{ docker_prune_timeout_secs }}"
+  poll: 5
+
 # Wait until Sia finished full setup
 - name: Wait until Sia finished full setup
   command: docker logs sia
@@ -77,12 +83,6 @@
 # Include waiting for sia daemon/ready
 - name: Include waiting for sia daemon/ready
   include_tasks: tasks/portal-wait-for-sia-daemon-ready.yml
-
-# Prune docker
-- name: Prune docker
-  ansible.builtin.command: docker system prune --force
-  async: "{{ docker_prune_timeout_secs }}"
-  poll: 5
 
 # Confirm all Docker Services Started Up
 - name: Wait Until Docker Services Have Started Up


### PR DESCRIPTION
# PULL REQUEST

## Overview

Current waiting for Nginx not restarting doesn't seem to work correctly/always.
Waiting for Nginx not restarting was moved later in the task, so that Nginx has time to restart and we can catch it.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
