### PR TITLE
Add variable to set number of parallel deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
         - [Deploy Skynet Webportal](#deploy-skynet-webportal)
             - [Deploy Playbook Actions:](#deploy-playbook-actions)
             - [Portal Modules](#portal-modules)
-            - [How to set portal, skyd, accounts versions:](#how-to-set-portal-skyd-accounts-versions)
+            - [How to set portal, skyd, accounts versions](#how-to-set-portal-skyd-accounts-versions)
+            - [How to enable parallel deployments](#how-to-enable-parallel-deployments)
             - [How to Set Deploy Batch](#how-to-set-deploy-batch)
         - [Takedown Skynet Webportal](#takedown-skynet-webportal)
             - [Playbook Actions](#playbook-actions)
@@ -214,7 +215,7 @@ or Jaeger defined in `docker-compose.accounts.yml` or
 Accounts and Jaeger docker compose files will be loaded according to the flag
 order in `PORTAL_MODULES`.
 
-#### How to set portal, skyd, accounts versions:
+#### How to set portal, skyd, accounts versions
 
 * Go to `my-vars`.
 * Copy `portal-versions.sample.do-not-edit.yml` as `portal-versions.yml`
@@ -235,6 +236,24 @@ To deploy portal at `eu-ger-1` and `us-pa-1` execute:
 `scripts/portals-deploy.sh -e @my-vars/portal-versions.yml --limit eu-ger-1,us-pa-1`  
 or:  
 `scripts/portals-deploy.sh -e @my-logs/last-portal-versions.yml --limit eu-ger-1.us-pa-1`
+
+#### How to enable parallel deployments
+
+By default portals-deploy playbook performs deployments one server at a time
+(rolling updates/deploys). You can enable parallel deployments (deploy to the
+given number of hosts in parallel) by setting optional `parallel_deploys`
+variable in used `portal-versions.yml`.
+
+Example `portal-versions.yml`:
+```yaml
+---
+
+portal_repo_version: "deploy-2021-08-24"
+portal_skyd_version: "deploy-2021-08-24"
+portal_accounts_version: "deploy-2021-08-23"
+
+parallel_deploys: 3
+```
 
 #### How to Set Deploy Batch
 

--- a/playbooks/portals-deploy.yml
+++ b/playbooks/portals-deploy.yml
@@ -11,7 +11,7 @@
   any_errors_fatal: True
 
   vars:
-    max_hosts: "{{ groups['webportals'] | length - 1 }}"
+    max_hosts: "{{ groups['webportals_prod'] | length - 1 }}"
 
     # Default batch config (one batch with all selected hosts will be created),
     # can be overriden with cli flag --extra-vars/-e

--- a/playbooks/portals-deploy.yml
+++ b/playbooks/portals-deploy.yml
@@ -2,19 +2,27 @@
   hosts: webportals
   gather_facts: False
 
-  # Limit concurrency to keep batch_hosts order deterministic
+  # Limit concurrency to keep batch_hosts order deterministic.
+  # When you want to deploy in parallel, keep 'serial: 1' for this play,
+  # parallel deploys are set by 'serial' variable in the next play.
   serial: 1
 
   # Stop on first error, do not execute on the next host
   any_errors_fatal: True
 
   vars:
+    max_hosts: "{{ groups['webportals'] | length - 1 }}"
+
     # Default batch config (one batch with all selected hosts will be created),
     # can be overriden with cli flag --extra-vars/-e
     batch_size: 1
     batch_number: 1
 
   tasks:
+    # Check '--limit' is used
+    - name: Fail if you are targeting all dev and prod webportals
+      include_tasks: tasks/host-limit-check.yml
+
     - name: Filter hosts by batch size and batch number
       ansible.builtin.group_by:
         key: batch_hosts
@@ -28,14 +36,13 @@
   gather_facts: False
 
   # Limit concurrency
-  serial: 1
+  serial: "{{ parallel_deploys | default(1) }}"
 
   # Stop on first error, do not execute on the next host
   any_errors_fatal: True
 
   # Playbook specific vars
   vars:
-    max_hosts: "{{ groups['webportals'] | length - 1 }}"
     # Rebuild docker services
     docker_compose_build: True
     # Set portal, skyd, accounts versions
@@ -43,15 +50,11 @@
     portal_action: "portal-deploy"
 
   tasks:
-    # Check '--limit' is used
-    - name: Fail if you are targeting all dev and prod webportals
-      include_tasks: tasks/host-limit-check.yml
-
     # Print timestamp
     - name: Print timestamp
       debug:
         msg: "{{ inventory_hostname + ' deployment start: ' + lookup('pipe','date +%Y-%m-%dT%H:%M:%S') + ' UTC' }}"
-
+  
     # Check/install Ansible prerequisities
     - name: Include preparing portal prerequisities
       include_tasks: tasks/portals-prepare.yml


### PR DESCRIPTION
# PULL REQUEST

## Overview

Till now we have performed deployments sequentially (rolling updates) one server at a time.

This PR adds an optional variable `parallel_deploys` that can set number of servers to deploy to in parallel.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
