### PR TITLE
Update LastPass dirs to fix backslashes in server paths

### DIFF
--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -44,10 +44,10 @@ local_networks:
   - "169.254.0.0/16"
 
 # LastPass settings
-lastpass_ansible_config_dir: "Shared-Ansible/Portal-Configurations"
-lastpass_portal_config_common: "{{ lastpass_ansible_config_dir }}/Common/common.yml"
-lastpass_portal_config_cluster: "{{ lastpass_ansible_config_dir }}/Cluster/cluster-{{ portal_cluster_id }}.yml"
-lastpass_portal_config_server: "{{ lastpass_ansible_config_dir }}/Server/{{ inventory_hostname }}.yml"
+lastpass_ansible_dir: "Shared-Ansible"
+lastpass_portal_config_common: "{{ lastpass_ansible_dir }}/portal-common-configs/common.yml"
+lastpass_portal_config_cluster: "{{ lastpass_ansible_dir }}/portal-cluster-configs/cluster-{{ portal_cluster_id }}.yml"
+lastpass_portal_config_server: "{{ lastpass_ansible_dir }}/portal-server-configs/{{ inventory_hostname }}.yml"
 
 # Portal settings
 webportal_user_home_dir: "/home/{{ webportal_user }}"


### PR DESCRIPTION
# PULL REQUEST

## Overview

LastPass server is using `\` instead of `/` between some shared folder levels.

This PR updates Ansible LastPass dirs to keep using just `/`.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
