### PR TITLE
Fix bugs in deploy script

### DIFF
--- a/changelog/items/bugs-fixed/health-check-cli.md
+++ b/changelog/items/bugs-fixed/health-check-cli.md
@@ -1,0 +1,2 @@
+- Update syntax for health-check cli commands from updates on the skynet
+  webportal repo [here](https://github.com/SkynetLabs/skynet-webportal/pull/1179)

--- a/changelog/items/bugs-fixed/out_of_lb_message.md
+++ b/changelog/items/bugs-fixed/out_of_lb_message.md
@@ -1,0 +1,2 @@
+- Fix bug where the default case for the `out_of_lb_message` wasn't being
+  handled.

--- a/changelog/items/bugs-fixed/takedown-script-user.md
+++ b/changelog/items/bugs-fixed/takedown-script-user.md
@@ -1,0 +1,1 @@
+- Fix bug in the takedown script where the user wasn't probably defined.

--- a/changelog/items/key-updates/parallel-deploys.md
+++ b/changelog/items/key-updates/parallel-deploys.md
@@ -1,0 +1,1 @@
+- Add variable `parallel_deploys` to define how many servers should be deployed in parallel

--- a/playbooks/tasks/portal-health-check-disable.yml
+++ b/playbooks/tasks/portal-health-check-disable.yml
@@ -14,7 +14,7 @@
 - name: Stop portal healh check to take portal out of load balancer
   vars:
     disable_message: "{{  out_of_lb_message | default('') }}"
-  command: 'docker exec health-check cli/disable "{{ disable_message }}"'
+  command: 'docker exec health-check ./cli disable "{{ disable_message }}"'
   become: True
   become_user: "user"
   when: result.exists and result.container is defined and result.container.State.Running

--- a/playbooks/tasks/portal-health-check-disable.yml
+++ b/playbooks/tasks/portal-health-check-disable.yml
@@ -12,7 +12,9 @@
   register: result
 
 - name: Stop portal healh check to take portal out of load balancer
-  command: 'docker exec health-check cli/disable "{{ out_of_lb_message }}"'
+  vars:
+    disable_message: "{{  out_of_lb_message | default('') }}"
+  command: 'docker exec health-check cli/disable "{{ disable_message }}"'
   become: True
   become_user: "user"
   when: result.exists and result.container is defined and result.container.State.Running

--- a/playbooks/tasks/portal-health-check-disable.yml
+++ b/playbooks/tasks/portal-health-check-disable.yml
@@ -1,24 +1,27 @@
 ---
-# Take portal out of load balancer by stopping healh check
+# Take portal out of load balancer by stopping health check
 
-- name: Sleep before portal health check disabling
-  wait_for:
-    timeout: "{{ portal_health_check_disable_delay_secs }}"
-  delegate_to: localhost
-
+# Check if the health check container is running.
 - name: Check health check container is running
   community.docker.docker_container_info:
     name: health-check
-  register: result
+  register: health_check_docker_container_result
 
-- name: Stop portal healh check to take portal out of load balancer
-  vars:
-    disable_message: "{{  out_of_lb_message | default('') }}"
-  command: 'docker exec health-check ./cli disable "{{ disable_message }}"'
-  become: True
-  become_user: "user"
-  when: result.exists and result.container is defined and result.container.State.Running
+# Marker the health check as disabled via the cli command
+- name: Stop portal health check to take portal out of load balancer
+  # NOTE: portal_action is defined by the playbook, i.e. for deploys,
+  # portal_action='portal-deploy'
+  command: 'docker exec health-check cli disable "{{ out_of_lb_message | default(portal_action) }}"'
+  # Only execute the CLI command if the container is up and running. Otherwise,
+  # if it is not up and running, it is practically disabled.
+  when: health_check_docker_container_result.exists and health_check_docker_container_result.container is defined and health_check_docker_container_result.container.State.Running
 
+# This is a temporary solution to help allow uploads to finish. One piece of the
+# solution is listed below in a TODO. The second part of the solution is for
+# multi server large uploads, meaning TUS uploads can resume on another server.
+#
+# TODO: Replace this with a check if there are any in process uploads, wait for
+# them to finish in this timeout
 - name: "Wait given timeout for the load balancer to remove the portal"
   wait_for:
     timeout: "{{ portal_load_balancer_timeout_secs }}"

--- a/playbooks/tasks/portal-health-check-enable.yml
+++ b/playbooks/tasks/portal-health-check-enable.yml
@@ -10,7 +10,7 @@
   # reason for the failure is the docker container and not the cli command.
   failed_when: >
     (health_check_docker_container_result.exists is not defined) or
-    (health_check_docker_container_result.exists is not defined) or
+    (health_check_docker_container_result.container is not defined) or
     (not health_check_docker_container_result.container.State.Running)
 
 # Mark the health check as enabled via the cli command

--- a/playbooks/tasks/portal-health-check-enable.yml
+++ b/playbooks/tasks/portal-health-check-enable.yml
@@ -1,7 +1,18 @@
 ---
 # Enable portal health check to add portal to load balancer
 
-- name: Enable portal healh check to add portal to load balancer
-  command: docker exec health-check ./cli enable
-  become: True
-  become_user: "user"
+# Check if the health check container is running
+- name: Check health check container is running
+  community.docker.docker_container_info:
+    name: health-check
+  register: health_check_docker_container_result
+  # If the container is not up and running, fail here so that it is clear the
+  # reason for the failure is the docker container and not the cli command.
+  failed_when: >
+    (health_check_docker_container_result.exists is not defined) or
+    (health_check_docker_container_result.exists is not defined) or
+    (not health_check_docker_container_result.container.State.Running)
+
+# Mark the health check as enabled via the cli command
+- name: Enable portal health check to add portal to load balancer
+  command: docker exec health-check cli enable

--- a/playbooks/tasks/portal-health-check-enable.yml
+++ b/playbooks/tasks/portal-health-check-enable.yml
@@ -1,8 +1,7 @@
 ---
-
 # Enable portal health check to add portal to load balancer
 
 - name: Enable portal healh check to add portal to load balancer
-  command: docker exec health-check cli/enable
+  command: docker exec health-check ./cli enable
   become: True
   become_user: "user"

--- a/playbooks/tasks/portal-health-checks-run.yml
+++ b/playbooks/tasks/portal-health-checks-run.yml
@@ -10,7 +10,7 @@
   # reason for the failure is the docker container and not the cli command.
   failed_when: >
     (health_check_docker_container_result.exists is not defined) or
-    (health_check_docker_container_result.exists is not defined) or
+    (health_check_docker_container_result.container is not defined) or
     (not health_check_docker_container_result.container.State.Running)
 
 # Run critical health checks

--- a/playbooks/tasks/portal-health-checks-run.yml
+++ b/playbooks/tasks/portal-health-checks-run.yml
@@ -1,13 +1,12 @@
 ---
-
 # Run webportal health checks
 
 # Run critical health checks
 - name: Run critical health checks
-  command: docker exec health-check cli/run critical
+  command: docker exec health-check ./cli run critical
   changed_when: False
 
 # Run extended health checks
 - name: Run extended health checks
-  command: docker exec health-check cli/run extended
+  command: docker exec health-check ./cli run extended
   changed_when: False

--- a/playbooks/tasks/portal-health-checks-run.yml
+++ b/playbooks/tasks/portal-health-checks-run.yml
@@ -1,12 +1,24 @@
 ---
 # Run webportal health checks
 
+# Check if the health check container is running
+- name: Check health check container is running
+  community.docker.docker_container_info:
+    name: health-check
+  register: health_check_docker_container_result
+  # If the container is not up and running, fail here so that it is clear the
+  # reason for the failure is the docker container and not the cli command.
+  failed_when: >
+    (health_check_docker_container_result.exists is not defined) or
+    (health_check_docker_container_result.exists is not defined) or
+    (not health_check_docker_container_result.container.State.Running)
+
 # Run critical health checks
 - name: Run critical health checks
-  command: docker exec health-check ./cli run critical
+  command: docker exec health-check cli run critical
   changed_when: False
 
 # Run extended health checks
 - name: Run extended health checks
-  command: docker exec health-check ./cli run extended
+  command: docker exec health-check cli run extended
   changed_when: False


### PR DESCRIPTION
# PULL REQUEST

## Overview
The default case for the `out_of_lb_message` being blank was not being handled. This defines a variable as a helper as well.

Also updated the syntax for how the health check cli is called based on this PR <https://github.com/SkynetLabs/skynet-webportal/pull/1179> from @kwypchlo 

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->
This error would case the deploy script to fail. Not it passes that error condition.

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
