### PR TITLE
Fix not yet saved portal config empty value

### DIFF
--- a/changelog/items/bugs-fixed/missing-server-config-fix.md
+++ b/changelog/items/bugs-fixed/missing-server-config-fix.md
@@ -1,0 +1,3 @@
+- Fixed a server config issue (config not defined) in `portal-setup-following`
+  during setting server config default values when server config was not yet
+  created in secure backend (LastPass).

--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -20,6 +20,10 @@
 - name: Include loading portal config
   include_tasks: "{{ playbook_dir }}/{{ load_portal_config_handler }}"
 
+- name: Set portal config to empty if it hasn't yet been saved to secrets backend
+  set_fact:
+    webportal_server_config: "{{ webportal_server_config | default({}) }}"
+
 - name: Set portal config missing variables to default values
   set_fact:
     webportal_server_config: "{{ webportal_server_config | combine({item.key: item.value}) }}"


### PR DESCRIPTION
# PULL REQUEST

## Overview

Fix for setting default portal config values issue when portal config was not yet saved in secrets backup (LastPass).

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
