### PR TITLE
Switch out sleep with uploads check for disable health check

### DIFF
--- a/changelog/items/key-updates/wait-for-uploads.md
+++ b/changelog/items/key-updates/wait-for-uploads.md
@@ -1,0 +1,2 @@
+- Switch out simple sleep with waiting for no uploads in siac renter uploads
+  when disabling health check.

--- a/playbooks/group_vars/webportals_dev.yml
+++ b/playbooks/group_vars/webportals_dev.yml
@@ -1,3 +1,3 @@
-# Time to wait for load balancer to remove portal after portal health check is
-# disabled
-portal_load_balancer_timeout_secs: 0
+# The number of times the portal will check for uploads before shutting down the
+# docker services after disabling the health checks.
+portal_upload_num_retries: 0

--- a/playbooks/group_vars/webportals_prod.yml
+++ b/playbooks/group_vars/webportals_prod.yml
@@ -1,3 +1,3 @@
-# Time to wait for load balancer to remove portal after portal health check is
-# disabled
-portal_load_balancer_timeout_secs: 300
+# The number of times the portal will check for uploads before shutting down the
+# docker services after disabling the health checks.
+portal_upload_num_retries: 60

--- a/playbooks/tasks/portal-health-check-disable.yml
+++ b/playbooks/tasks/portal-health-check-disable.yml
@@ -22,6 +22,9 @@
 - name: "Wait for uploads to finish"
   ansible.builtin.command: docker exec sia siac renter uploads
   register: docker_renter_uploads
+  # Wait until 'No files are uploading.' is found in the stdout.
   until: docker_renter_uploads.stdout.find("No files are uploading.") != -1
+  # Retry every 5 seconds for portal_upload_num_retries, in prod this is 60
+  # times which is where the 5 minutes is determined in the above comment.
   delay: 5
   retries: "{{ portal_upload_num_retries }}"

--- a/playbooks/tasks/portal-health-check-disable.yml
+++ b/playbooks/tasks/portal-health-check-disable.yml
@@ -16,13 +16,12 @@
   # if it is not up and running, it is practically disabled.
   when: health_check_docker_container_result.exists and health_check_docker_container_result.container is defined and health_check_docker_container_result.container.State.Running
 
-# This is a temporary solution to help allow uploads to finish. One piece of the
-# solution is listed below in a TODO. The second part of the solution is for
-# multi server large uploads, meaning TUS uploads can resume on another server.
-#
-# TODO: Replace this with a check if there are any in process uploads, wait for
-# them to finish in this timeout
-- name: "Wait given timeout for the load balancer to remove the portal"
-  wait_for:
-    timeout: "{{ portal_load_balancer_timeout_secs }}"
-  delegate_to: localhost
+# Wait 5 minutes for any small uploads to finish. After 5 minutes, it is likely
+# that it is a large upload in which case it is safe to take the server down as
+# the large upload will continue on another server.
+- name: "Wait for uploads to finish"
+  ansible.builtin.command: docker exec sia siac renter uploads
+  register: docker_renter_uploads
+  until: docker_renter_uploads.stdout.find("No files are uploading.") != -1
+  delay: 5
+  retries: "{{ portal_load_balancer_timeout_secs }}"

--- a/playbooks/tasks/portal-health-check-disable.yml
+++ b/playbooks/tasks/portal-health-check-disable.yml
@@ -24,4 +24,4 @@
   register: docker_renter_uploads
   until: docker_renter_uploads.stdout.find("No files are uploading.") != -1
   delay: 5
-  retries: "{{ portal_load_balancer_timeout_secs }}"
+  retries: "{{ portal_upload_num_retries }}"


### PR DESCRIPTION
# PULL REQUEST

## Overview
Switch out simple sleep with active uploads check for disabling health check.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
