### PR TITLE
Print timestamp before starting docker services

### DIFF
--- a/changelog/items/other/docker-start-timestamp.md
+++ b/changelog/items/other/docker-start-timestamp.md
@@ -1,0 +1,1 @@
+- Print timestamp to Ansible console log before starting docker services.

--- a/playbooks/tasks/portal-docker-services-start.yml
+++ b/playbooks/tasks/portal-docker-services-start.yml
@@ -53,6 +53,11 @@
     path: "{{ logs_dir }}/{{ log_filename_prefix }}.status.starting"
     state: touch
 
+# Print timestamp
+- name: Print timestamp (starting docker services)
+  debug:
+    msg: "{{ inventory_hostname + ' docker services start: ' + lookup('pipe','date +%Y-%m-%dT%H:%M:%S') + ' UTC' }}"
+
 # Start the docker services (on deploy also build images)
 - name: Start the docker services (on deploy also build images)
   community.docker.docker_compose:


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR add printing timestamp just before starting docker services.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
