### PR TITLE
Fix waiting for uploads when sia container is not running

### DIFF
--- a/playbooks/tasks/portal-health-check-disable.yml
+++ b/playbooks/tasks/portal-health-check-disable.yml
@@ -16,16 +16,23 @@
   # if it is not up and running, it is practically disabled.
   when: health_check_docker_container_result.exists and health_check_docker_container_result.container is defined and health_check_docker_container_result.container.State.Running
 
+# Check if sia container is running.
+- name: Check sia container is running
+  community.docker.docker_container_info:
+    name: sia
+  register: sia_docker_container_result
+
 # Wait 5 minutes for any small uploads to finish. After 5 minutes, it is likely
 # that it is a large upload in which case it is safe to take the server down as
 # the large upload will continue on another server.
 - name: "Wait for uploads to finish"
   ansible.builtin.command: docker exec sia siac renter uploads
   register: docker_renter_uploads
-  # Wait until 'No files are uploading.' is found in the stdout, do not wait
-  # when sia container is not running.
-  until: docker_renter_uploads.stdout.find("No files are uploading.") != -1 or docker_renter_uploads.stdout.find("No such container") != -1
+  # Wait until 'No files are uploading.' is found in the stdout.
+  until: docker_renter_uploads.stdout.find("No files are uploading.") != -1
   # Retry every 5 seconds for portal_upload_num_retries, in prod this is 60
   # times which is where the 5 minutes is determined in the above comment.
   delay: 5
   retries: "{{ portal_upload_num_retries }}"
+  # Do not wait if sia container is not running
+  when: sia_docker_container_result.exists and sia_docker_container_result.container is defined and sia_docker_container_result.container.State.Running

--- a/playbooks/tasks/portal-health-check-disable.yml
+++ b/playbooks/tasks/portal-health-check-disable.yml
@@ -22,8 +22,9 @@
 - name: "Wait for uploads to finish"
   ansible.builtin.command: docker exec sia siac renter uploads
   register: docker_renter_uploads
-  # Wait until 'No files are uploading.' is found in the stdout.
-  until: docker_renter_uploads.stdout.find("No files are uploading.") != -1
+  # Wait until 'No files are uploading.' is found in the stdout, do not wait
+  # when sia container is not running.
+  until: docker_renter_uploads.stdout.find("No files are uploading.") != -1 or docker_renter_uploads.stdout.find("No such container") != -1
   # Retry every 5 seconds for portal_upload_num_retries, in prod this is 60
   # times which is where the 5 minutes is determined in the above comment.
   delay: 5


### PR DESCRIPTION
# PULL REQUEST

## Overview

Currently, when sia container is running, we wait and fail waiting for uploads.

This PR stops waiting for uploads when sia container is not running.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
