### PR TITLE
Tighten allowed outgoing traffic by ufw rules

### DIFF
--- a/changelog/items/other/tighten-ufw-local-networks.md
+++ b/changelog/items/other/tighten-ufw-local-networks.md
@@ -1,0 +1,1 @@
+- Tighten allowed outgoing traffic to local networks by ufw firewall.

--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -35,7 +35,9 @@ group_ufw_rules:
   - { rule: "allow", port: "80", proto: "tcp", direction: "in" }
   - { rule: "allow", port: "443", proto: "tcp", direction: "in" }
 ufw_deny_outgoing_to_local_network: True
-local_networks:
+local_networks_allowed:
+  - "10.10.10.10/24"
+local_networks_denied:
   - "10.0.0.0/8"
   - "172.16.0.0/12"
   - "192.168.0.0/16"

--- a/playbooks/tasks/portal-firewall-ufw-setup.yml
+++ b/playbooks/tasks/portal-firewall-ufw-setup.yml
@@ -41,17 +41,22 @@
         - 443
         - 26257
         - 27017
-    
+
+    - name: Allow outgoing traffic to docker local network
+      community.general.ufw:
+        rule: "allow"
+        proto: "any"
+        direction: "out"
+        to_ip: "{{ item }}"
+      loop: "{{ local_networks_allowed }}"      
+
     - name: Deny outgoing traffic to local networks
       community.general.ufw:
         rule: "deny"
         proto: "any"
         direction: "out"
         to_ip: "{{ item }}"
-      # Exception: Do not deny traffic to 10.0.0.0/8 because we need to
-      # connect to various docker services on this network.
-      when: "'10.0.0.0' not in item"
-      loop: "{{ local_networks }}"
+      loop: "{{ local_networks_denied }}"
 
   # On error set at least SSH rule and enable firewall
   always:


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR tightens allowed outgoing traffic to local network rules by UFW firewall.

From local networks we only allow `10.10.10.0/24` used by portal docker services, the rest of the networks are denied.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
