### PR TITLE
Fix logging ansible version log

### DIFF
--- a/playbooks/portals-setup-following.yml
+++ b/playbooks/portals-setup-following.yml
@@ -35,6 +35,12 @@
     - name: Include server setup
       include_tasks: tasks/portal-setup-server.yml
 
+    - name: Include getting log filename prefix
+      include_tasks: tasks/portal-get-log-filename-prefix.yml
+    
+    - name: Include getting Ansible repo branch and commit
+      include_tasks: tasks/playbook-version-get.yml
+
     - name: Include logging Ansible version
       include_tasks: tasks/playbook-logs-ansible-log-version.yml
 

--- a/playbooks/tasks/portal-docker-services-start.yml
+++ b/playbooks/tasks/portal-docker-services-start.yml
@@ -7,9 +7,8 @@
   include_tasks: tasks/portal-docker-compose-files-get-wanted.yml
 
 # Create timestamped log filename prefix
-- name: Create timestamped log filename prefix
-  set_fact:
-    log_filename_prefix: "{{ lookup('pipe','date +%Y-%m-%dT%H-%M-%S') }}.{{ portal_action }}.{{ inventory_hostname }}"
+- name: Include getting log filename prefix
+  include_tasks: tasks/portal-get-log-filename-prefix.yml
 
 # Include getting Ansible repo branch and commit
 - name: Include getting Ansible repo branch and commit

--- a/playbooks/tasks/portal-get-log-filename-prefix.yml
+++ b/playbooks/tasks/portal-get-log-filename-prefix.yml
@@ -1,0 +1,7 @@
+---
+
+# Get Log Filename Prefix
+
+- name: Get log filename prefix
+  set_fact:
+    log_filename_prefix: "{{ lookup('pipe','date +%Y-%m-%dT%H-%M-%S') }}.{{ portal_action }}.{{ inventory_hostname }}"


### PR DESCRIPTION
# PULL REQUEST

## Overview

One more fix to fix logging Ansible version in `portal-setup-following`.
Tested with `portal-setup-following` and `portal-deploy` scripts.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
