### PR TITLE
Ask user before deleting mongo database

### DIFF
--- a/changelog/items/other/confirm-mongo-db-reset.md
+++ b/changelog/items/other/confirm-mongo-db-reset.md
@@ -1,0 +1,1 @@
+- Ask user to confirm MongoDB deletion/reset.

--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -60,8 +60,10 @@ setup_status_dir: "{{ devops_dir }}/setup"
 setup_status_file: "{{ setup_status_dir }}/status"
 devops_scripts_dir: "{{ devops_dir }}/scripts"
 webportal_cron_file: "{{ webportal_dir }}/setup-scripts/support/crontab"
-mongo_db_dir: "{{ webportal_dir}}/docker/data/mongo/db"
-mongo_mgkey_file: "{{ webportal_dir}}/docker/data/mongo/mgkey"
+mongo_data_dir: "{{ webportal_dir }}/docker/data/mongo"
+mongo_db_dir: "{{ mongo_data_dir }}/db"
+mongo_backups_dir: "{{ mongo_data_dir }}/backups"
+mongo_mgkey_file: "{{ mongo_data_dir }}/mgkey"
 
 # Default service ports
 default_mongo_port: 27017

--- a/playbooks/tasks/portal-role-task-mongo-setup-docker-service.yml
+++ b/playbooks/tasks/portal-role-task-mongo-setup-docker-service.yml
@@ -38,6 +38,28 @@
 
 # Reset mongo service if it is not running correctly
 - block:
+    - name: Ask user if it is ok to delete, reset MongoDB database
+      pause:
+        prompt: |-
+          Your MongoDB database doesn't run as expected.
+
+          If you do not have any data in your database
+          it is safe to continue (MongoDB database will be deleted and reset).
+          
+          If you have production data in your database
+          you should fix this issue manually and rerun this playbook.
+          
+          Do you want to reset MongoDB database on {{ inventory_hostname }} (y/n)?
+      register: reset_db_result
+      delegate_to: localhost
+
+    - name: Stop the playbook if the user doesn't want to delete, reset MongoDB database
+      fail:
+        msg: |
+          Your MongoDB database doesn't run as expected,
+          you have to fix it manually and then rerun this playbook.
+      when: reset_db_result.user_input[:1] not in 'yY'
+    
     - name: Stop and remove mongo container
       community.docker.docker_container:
         name: mongo

--- a/playbooks/tasks/portal-role-task-mongo-setup-docker-service.yml
+++ b/playbooks/tasks/portal-role-task-mongo-setup-docker-service.yml
@@ -44,11 +44,13 @@
           Your MongoDB database doesn't run as expected.
 
           If you do not have any data in your database
-          it is safe to continue (MongoDB database will be deleted and reset).
+          it is safe to continue.
+          Your MongoDB database will be backupped to
+          {{ mongo_backups_dir }}, deleted and reset.
           
           If you have production data in your database
           you should fix this issue manually and rerun this playbook.
-          
+
           Do you want to reset MongoDB database on {{ inventory_hostname }} (y/n)?
       register: reset_db_result
       delegate_to: localhost

--- a/playbooks/tasks/portal-role-task-mongo-setup-docker-service.yml
+++ b/playbooks/tasks/portal-role-task-mongo-setup-docker-service.yml
@@ -66,10 +66,21 @@
         state: absent
         container_default_behavior: no_defaults
 
-    - name: Remove mongo/db directory
+    - name: Ensure mongo/backups directory exists
       ansible.builtin.file:
+        path: "{{ mongo_backups_dir }}"
+        owner: "{{ webportal_user }}"
+        group: "{{ webportal_user }}"
+        state: directory
+      become: True
+
+    - name: Backup and remove mongo/db directory
+      community.general.archive:
         path: "{{ mongo_db_dir }}"
-        state: absent
+        dest: "{{ mongo_backups_dir }}/db-backup-{{ ansible_date_time.iso8601 }}.tar.gz"
+        owner: "{{ webportal_user }}"
+        group: "{{ webportal_user }}"
+        remove: True
       become: True
     
     - name: Create empty mongo/db directory

--- a/playbooks/tasks/portal-role-task-mongo-setup-docker-service.yml
+++ b/playbooks/tasks/portal-role-task-mongo-setup-docker-service.yml
@@ -53,7 +53,7 @@
       register: reset_db_result
       delegate_to: localhost
 
-    - name: Stop the playbook if the user doesn't want to delete, reset MongoDB database
+    - name: Stop the playbook if the user doesn't want to delete and reset MongoDB database
       fail:
         msg: |
           Your MongoDB database doesn't run as expected,

--- a/playbooks/tasks/portal-role-task-mongo-setup-docker-service.yml
+++ b/playbooks/tasks/portal-role-task-mongo-setup-docker-service.yml
@@ -38,7 +38,7 @@
 
 # Reset mongo service if it is not running correctly
 - block:
-    - name: Ask user if it is ok to delete, reset MongoDB database
+    - name: Ask user if it is ok to delete and reset MongoDB database
       pause:
         prompt: |-
           Your MongoDB database doesn't run as expected.


### PR DESCRIPTION
# PULL REQUEST

## Overview

Playbook `portal-setup-following` deletes and resets MongoDB database when it doesn't run correctly (e.g. the playbook can't connect to Mongo shell using defined admin credentials).

This PR asks user if it is ok to delete, reset MongoDB database or if he wants to fix it manually e.g. in case there are production data in the database.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
