### PR TITLE
Increase docker compose down timeout for mongo primary to step down

### DIFF
--- a/changelog/items/other/increase-docker-down-timeout-for-mongo-primary.md
+++ b/changelog/items/other/increase-docker-down-timeout-for-mongo-primary.md
@@ -1,0 +1,2 @@
+- Increase stopping docker compose timeout so there is enough time for MongoDB
+  primary node to step down.

--- a/playbooks/tasks/portal-docker-services-stop.yml
+++ b/playbooks/tasks/portal-docker-services-stop.yml
@@ -10,5 +10,7 @@
     project_src: "{{ webportal_dir }}"
     files: "{{ webportal_docker_compose_files_present }}"
     state: absent
+    # Increase timeout for mongo primary node to step down
+    timeout: 30
   become: True
   become_user: "user"


### PR DESCRIPTION
# PULL REQUEST

## Overview

Increase docker compose down timeout so that there is enough time for MongoDB primary node to step down.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
