### PR TITLE
Add check for keeping MongoDB replicaset majority online

### DIFF
--- a/changelog/items/other/voting-members-majority-check.md
+++ b/changelog/items/other/voting-members-majority-check.md
@@ -1,0 +1,3 @@
+- Added check that we keep majority (> 50%) of MongoDB replicaset voting
+  members online before we stop mongo service during deployments, takedowns,
+  restarts etc.

--- a/playbooks/portals-deploy.yml
+++ b/playbooks/portals-deploy.yml
@@ -59,13 +59,9 @@
     - name: Include preparing portal prerequisities
       include_tasks: tasks/portals-prepare.yml
 
-    # Disable health check
-    - name: Include disabling portal health check
-      include_tasks: tasks/portal-health-check-disable.yml
-
-    # Stop portal docker services
-    - name: Include stopping portal docker services
-      include_tasks: tasks/portal-docker-services-stop.yml
+    # Disable health checks and stop docker services
+    - name: Include disabling health check and stopping portal docker services
+      include_tasks: tasks/portal-stop.yml
 
     # Rebuild docker images, start the docker services and log activities
     - name: Include starting portal docker services

--- a/playbooks/portals-restart.yml
+++ b/playbooks/portals-restart.yml
@@ -36,13 +36,9 @@
     - name: Include preparing portal prerequisities
       include_tasks: tasks/portals-prepare.yml
 
-    # Disable health check
-    - name: Include disabling portal health check
-      include_tasks: tasks/portal-health-check-disable.yml
-
-    # Stop portal docker services
-    - name: Include stopping portal docker services
-      include_tasks: tasks/portal-docker-services-stop.yml
+    # Disable health checks and stop docker services
+    - name: Include disabling health check and stopping portal docker services
+      include_tasks: tasks/portal-stop.yml
 
     # Start the docker services and log activities
     - name: Include starting portal docker services

--- a/playbooks/portals-rollback.yml
+++ b/playbooks/portals-rollback.yml
@@ -33,13 +33,9 @@
 
       when: "'webportals_takedown' in group_names"
 
-    # Disable health check
-    - name: Include disabling portal health check
-      include_tasks: tasks/portal-health-check-disable.yml
-
-    # Stop portal docker services
-    - name: Include stopping portal docker services
-      include_tasks: tasks/portal-docker-services-stop.yml
+    # Disable health checks and stop docker services
+    - name: Include disabling health check and stopping portal docker services
+      include_tasks: tasks/portal-stop.yml
 
     # Get last working config (status.tested)
     - name: Include getting last working portal versions (status.tested)

--- a/playbooks/portals-takedown.yml
+++ b/playbooks/portals-takedown.yml
@@ -33,13 +33,9 @@
           deployments and restarts later.
       when: "'webportals_takedown' not in group_names"
     
-    # Disable health check
-    - name: Include disabling portal health check
-      include_tasks: tasks/portal-health-check-disable.yml
-    
-    # Stop portal docker services
-    - name: Include stopping portal docker services
-      include_tasks: tasks/portal-docker-services-stop.yml
+    # Disable health checks and stop docker services
+    - name: Include disabling health check and stopping portal docker services
+      include_tasks: tasks/portal-stop.yml
     
     # Include getting wanted docker-compose files
     - name: Include getting wanted docker-compose files

--- a/playbooks/tasks/portal-mongo-replicaset-check-majority.yml
+++ b/playbooks/tasks/portal-mongo-replicaset-check-majority.yml
@@ -35,18 +35,20 @@
               .filter(m => m.priority > 0)
               .map(m => m.host)
             onlineVotingMembers = rs.status().members
-              .filter(m => m.stateStr == 'PRIMARY' || m.stateStr == 'SECONDARY')
+              .filter(m => (m.stateStr == 'PRIMARY' || m.stateStr == 'SECONDARY') && m.health == 1)
               .map(m => m.name)
               .filter(m => votingMembers.includes(m))
             batchMembers = [{% for h in ansible_play_batch -%}
               '{{ hostvars[h].ansible_host + ':' + (hostvars[h].subcrap_mongo_port | default(default_mongo_port) | string) }}'{{ loop.last | ternary('', ', ') }}
               {%- endfor -%}]
             onlineVotingMembersAfter = onlineVotingMembers.filter(m => !batchMembers.includes(m))
+            thisMemberIsVoting = votingMembers.includes('{{ ansible_host + ':' + (subcrap_mongo_port | default(default_mongo_port) | string) }}')
             result = {
               "votingMembers": votingMembers,
               "onlineVotingMembers": onlineVotingMembers,
               "batchMembers": batchMembers,
               "onlineVotingMembersAfter": onlineVotingMembersAfter,
+              "thisMemberIsVoting": thisMemberIsVoting,
               "replicasetMajorityOk": onlineVotingMembersAfter.length > votingMembers.length/2
             }
           until: True
@@ -64,7 +66,7 @@
           - Voting members in config: {{ mongo_replicaset_result.votingMembers | length }}
             {{ mongo_replicaset_result.votingMembers }}
 
-          - Voting members currently online: {{ mongo_replicaset_result.onlineVotingMembers | length }}
+          - Voting members currently online and healthy: {{ mongo_replicaset_result.onlineVotingMembers | length }}
             {{ mongo_replicaset_result.onlineVotingMembers }}
 
           - Members in the current Ansible batch: {{ mongo_replicaset_result.batchMembers | length }}
@@ -81,6 +83,7 @@
           - Don't stop so many voting members in one Ansible batch
           - Reconfigure voting members (move voting from an offline member to some online member)
       when: >-
+        mongo_replicaset_result.thisMemberIsVoting and
         mongo_replicaset_result.votingMembers | length > 2 and
         not mongo_replicaset_result.replicasetMajorityOk
   when:

--- a/playbooks/tasks/portal-mongo-replicaset-check-majority.yml
+++ b/playbooks/tasks/portal-mongo-replicaset-check-majority.yml
@@ -1,0 +1,89 @@
+---
+
+# Check there is still MongoDB majority if we turn off hosts in the current batch
+
+- name: Check mongo container is running
+  community.docker.docker_container_info:
+    name: mongo
+  register: mongo_docker_container_result
+
+# If the mongo container is already stopped we can skip MongoDB replicaset
+# majority check, it doesn't matter that we stop the rest of services.
+- block:
+    # Set mongo db config from .env file (without using LastPass/secrets storage)
+
+    - name: Get mongo user on host_item from .env file
+      ansible.builtin.shell: ". {{ webportal_dir }}/.env && echo $SKYNET_DB_USER"
+      register: skynet_db_user_result
+
+    - name: Get mongo pass on host_item from .env file
+      ansible.builtin.shell: ". {{ webportal_dir }}/.env && echo $SKYNET_DB_PASS"
+      register: skynet_db_pass_result
+
+    - name: Set mongo db config
+      set_fact:
+        mongodb_config:
+          skynet_db_user: "{{ skynet_db_user_result.stdout }}"
+          skynet_db_pass: "{{ skynet_db_pass_result.stdout }}"
+
+    - name: Include checking mongo replicaset majority
+      include_tasks: tasks/portal-role-task-mongo-shell-eval.yml
+      vars:
+        mongodb_shell:
+          eval: |
+            votingMembers = rs.config().members
+              .filter(m => m.priority > 0)
+              .map(m => m.host)
+            onlineVotingMembers = rs.status().members
+              .filter(m => m.stateStr == 'PRIMARY' || m.stateStr == 'SECONDARY')
+              .map(m => m.name)
+              .filter(m => votingMembers.includes(m))
+            batchMembers = [{% for h in ansible_play_batch -%}
+              '{{ hostvars[h].ansible_host + ':' + (hostvars[h].subcrap_mongo_port | default(default_mongo_port) | string) }}'{{ loop.last | ternary('', ', ') }}
+              {%- endfor -%}]
+            onlineVotingMembersAfter = onlineVotingMembers.filter(m => !batchMembers.includes(m))
+            result = {
+              "votingMembers": votingMembers,
+              "onlineVotingMembers": onlineVotingMembers,
+              "batchMembers": batchMembers,
+              "onlineVotingMembersAfter": onlineVotingMembersAfter,
+              "replicasetMajorityOk": onlineVotingMembersAfter.length > votingMembers.length/2
+            }
+          until: True
+          retries: 0
+
+    - name: Set mongo replicaset result
+      set_fact:
+        mongo_replicaset_result: "{{ mongo_shell_result.transformed_output | from_json }}"
+
+    - name: Stop the playbook if we don't have majority (> 50%) MongoDB replicaset voting members online
+      fail:
+        msg: |
+          MongoDB status:
+
+          - Voting members in config: {{ mongo_replicaset_result.votingMembers | length }}
+            {{ mongo_replicaset_result.votingMembers }}
+
+          - Voting members currently online: {{ mongo_replicaset_result.onlineVotingMembers | length }}
+            {{ mongo_replicaset_result.onlineVotingMembers }}
+
+          - Members in the current Ansible batch: {{ mongo_replicaset_result.batchMembers | length }}
+            {{ mongo_replicaset_result.batchMembers }}
+
+          - Voting members online if we continue: {{ mongo_replicaset_result.onlineVotingMembersAfter | length }}
+            {{ mongo_replicaset_result.onlineVotingMembersAfter }}
+
+          The playbook stops otherwise you don't have more than half MongoDB replicaset voting members online
+          and MongoDB service would be disrupted.
+
+          How to fix this MongoDB issue:
+          - Bring more voting members online
+          - Don't stop so many voting members in one Ansible batch
+          - Reconfigure voting members (move voting from an offline member to some online member)
+      when: >-
+        mongo_replicaset_result.votingMembers | length > 2 and
+        not mongo_replicaset_result.replicasetMajorityOk
+  when:
+    - mongo_docker_container_result.exists
+    - mongo_docker_container_result.container is defined
+    - mongo_docker_container_result.container.State.Running

--- a/playbooks/tasks/portal-role-task-mongo-check-docker-service.yml
+++ b/playbooks/tasks/portal-role-task-mongo-check-docker-service.yml
@@ -83,6 +83,7 @@
       eval: "db.serverStatus()"
       until: "'\"ok\" : 1' in mongo_shell_result.transformed_output"
       retries: 20
+      ignore_errors: True
   when: mongo_service_ok
   register: mongo_checking_admin_result
 
@@ -113,6 +114,7 @@
         })
       until: mongo_shell_result.transformed_output in ['PRIMARY', 'SECONDARY']
       retries: 120
+      ignore_errors: True
   when: mongo_service_ok
   register: checking_replicaset_result
 

--- a/playbooks/tasks/portal-role-task-mongo-shell-eval.yml
+++ b/playbooks/tasks/portal-role-task-mongo-shell-eval.yml
@@ -1,7 +1,8 @@
 ---
 
 # Run MongoDB shell command
-# TODO: This ansible playbook task, should be moved to portal role
+# TODO: This ansible playbook task, should be copied to portal role and also
+# kept for playbooks.
 
 - name: Run mongo shell command
   community.mongodb.mongodb_shell:
@@ -19,4 +20,4 @@
   until: mongodb_shell.until
   delay: 1
   retries: "{{ mongodb_shell.retries }}"
-  ignore_errors: True
+  ignore_errors: "{{ mongodb_shell.ignore_errors | default(False) }}"

--- a/playbooks/tasks/portal-stop.yml
+++ b/playbooks/tasks/portal-stop.yml
@@ -1,0 +1,12 @@
+---
+
+# Disable health checks and stop docker services
+
+- name: Include checking majority of MongoDB voting members
+  include_tasks: tasks/portal-mongo-replicaset-check-majority.yml
+
+- name: Include disabling portal health check
+  include_tasks: tasks/portal-health-check-disable.yml
+
+- name: Include stopping portal docker services
+  include_tasks: tasks/portal-docker-services-stop.yml


### PR DESCRIPTION
# PULL REQUEST

## Overview

Currently there is a risk that we stop portal mongo services during deploys, takedowns, etc. and there will be only 50% or less of MongoDB voting members online, which will disrupt portal operation.

This PR adds a check before stoping mongo service to be sure we keep > 50% MongoDB voting members online during execution of our playbooks.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
