### PR TITLE
Add playbook for gzipping logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
             - [Playbook portals-setup-following](#playbook-portals-setup-following)
             - [Playbook portals-deploy](#playbook-portals-deploy)
         - [Run Docker Command](#run-docker-command)
+        - [GZIP Logs](#gzip-logs)
         - [Update Allowance](#update-allowance)
     - [Playbook Live Demos](#playbook-live-demos)
     - [Troubleshooting](#troubleshooting)
@@ -649,6 +650,15 @@ Execute (e.g. on `eu-fin-5`):
 
 To finish portal setup and deployment execute portal deploy playbook (see
 separate section above).
+
+### GZIP Logs
+
+Playbook:
+
+- GZIP log files on the portal to save disk space.
+
+To run:  
+`scripts/portals-gzip-logs.sh --limit eu-fin-1`
 
 ### Run Docker Command
 

--- a/changelog/items/key-updates/add-gzip-playbook.md
+++ b/changelog/items/key-updates/add-gzip-playbook.md
@@ -1,0 +1,1 @@
+- Add playbook for gzipping logs

--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -180,11 +180,11 @@ private_vars_file: "../../../ansible-private/private-vars/private-vars.yml"
 
 # Portal log file paths
 portal_log_files:
-  - "/home/user/skynet-webportal/docker/data/sia/renter/contractor.log"
-  - "/home/user/skynet-webportal/docker/data/sia/renter/hostdb.log"
-  - "/home/user/skynet-webportal/docker/data/sia/renter/renter.log"
-  - "/home/user/skynet-webportal/docker/data/sia/renter/repair.log"
-  - "/home/user/skynet-webportal/docker/data/sia/siamux/siamux.log"
+  - "{{ webportal_dir }}/docker/data/sia/renter/contractor.log"
+  - "{{ webportal_dir }}/docker/data/sia/renter/hostdb.log"
+  - "{{ webportal_dir }}/docker/data/sia/renter/renter.log"
+  - "{{ webportal_dir }}/docker/data/sia/renter/repair.log"
+  - "{{ webportal_dir }}/docker/data/sia/siamux/siamux.log"
 
 # The size limit at which log files will be gzipped 1GB
 # 1GB 1073741824

--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -177,3 +177,16 @@ docker_services_exclude_waiting:
 local_logs_dir: "../my-logs"
 # Path relative to ./playbooks/vars directory
 private_vars_file: "../../../ansible-private/private-vars/private-vars.yml"
+
+# Portal log file paths
+portal_log_files:
+  - "/home/user/skynet-webportal/docker/data/sia/renter/contractor.log"
+  - "/home/user/skynet-webportal/docker/data/sia/renter/hostdb.log"
+  - "/home/user/skynet-webportal/docker/data/sia/renter/renter.log"
+  - "/home/user/skynet-webportal/docker/data/sia/renter/repair.log"
+  - "/home/user/skynet-webportal/docker/data/sia/siamux/siamux.log"
+
+# The size limit at which log files will be gzipped 1GB
+# 1GB 1073741824
+# 5GB 5368709120
+portal_log_size_gzip_limit: 5368709120

--- a/playbooks/portals-gzip-logs.yml
+++ b/playbooks/portals-gzip-logs.yml
@@ -1,0 +1,77 @@
+- name: GZIP Skynet Webportals Logs
+  hosts: webportals
+  remote_user: "{{ webportal_user }}"
+  gather_facts: False
+
+  # Limit concurrency
+  serial: 1
+
+  # Stop on first error, do not execute on the next host
+  any_errors_fatal: True
+
+  # Playbook specific vars
+  vars:
+    max_hosts: "{{ groups['webportals'] | length - 1 }}"
+    docker_compose_build: False
+    set_portal_versions: False
+    portal_action: "portal-gzip-logs"
+    lastpass_required: True
+
+  tasks:
+    # Check '--limit' is used
+    - name: Fail if you are targeting all dev and prod webportals
+      include_tasks: tasks/host-limit-check.yml
+
+    # Check/install Ansible prerequisities
+    - name: Include preparing portal prerequisities
+      include_tasks: tasks/portals-prepare.yml
+
+    # Disable health checks and stop docker services
+    - name: Include disabling health check and stopping portal docker services
+      include_tasks: tasks/portal-stop.yml
+
+    # gzip logs
+    - name: GZIP Webportal Logs
+      include_tasks: tasks/portal-gzip-logs.yml
+
+    # Start the docker services and log activities
+    - name: Include starting portal docker services
+      include_tasks: tasks/portal-docker-services-start.yml
+
+    # Run portal integration tests
+    - name: Include running portal integration tests
+      include_tasks: tasks/portal-integration-tests-run.yml
+
+    # Include running portal health checks
+    - name: Include running portal health checks
+      include_tasks: tasks/portal-health-checks-run.yml
+
+    # Takedown portals in takedown group
+    - block:
+        # Include getting wanted docker-compose files
+        - name: Include getting wanted docker-compose files
+          include_tasks: tasks/portal-docker-compose-files-get-wanted.yml
+
+        # Start just sia docker service
+        - name: Start just sia docker service
+          community.docker.docker_compose:
+            project_src: "{{ webportal_dir }}"
+            files: "{{ webportal_docker_compose_files_wanted }}"
+            build: False
+            nocache: True
+            pull: True
+            services: sia
+            state: present
+          become: True
+          become_user: "user"
+
+        - name: Stop play for portals in webportals_takedown group
+          meta: end_host
+
+      when: "'webportals_takedown' in group_names"
+
+    # Enable health check
+    - name: Include enabling portal health check
+      # do not enable health checks on hosts from out_of_LB group
+      when: ('out_of_LB' not in group_names)
+      include_tasks: tasks/portal-health-check-enable.yml

--- a/playbooks/portals-gzip-logs.yml
+++ b/playbooks/portals-gzip-logs.yml
@@ -48,6 +48,11 @@
 
     # Takedown portals in takedown group
     - block:
+        # Stop the docker services again. Use portal-stop to include mongo
+        # voting members check for safety.
+        - name: Include disabling health check and stopping portal docker services
+          include_tasks: tasks/portal-stop.yml
+
         # Include getting wanted docker-compose files
         - name: Include getting wanted docker-compose files
           include_tasks: tasks/portal-docker-compose-files-get-wanted.yml

--- a/playbooks/tasks/portal-gzip-logs.yml
+++ b/playbooks/tasks/portal-gzip-logs.yml
@@ -1,0 +1,24 @@
+# GZIP webportal logs
+
+# Stat all the portal_log_files.
+- name: Stat Files
+  ansible.builtin.stat:
+    path: "{{ file }}"
+  register: loop_results
+  loop: "{{ portal_log_files }}"
+  loop_control:
+    loop_var: file
+  when: portal_log_files is defined
+  become: True
+
+# GZIP any files over the portal_log_size_gzip_limit
+- name: GZIP Files
+  community.general.archive:
+    path: "{{ file.stat.path }}"
+    dest: "{{ file.stat.path + lookup('pipe','date +%Y-%m-%dT%H:%M:%S') + '.gz' }}"
+    remove: yes
+  loop: "{{ loop_results.results | from_yaml | list }}"
+  loop_control:
+    loop_var: file
+    label: "{{ file.stat.path }}"
+  when: file.stat.size | int > portal_log_size_gzip_limit | int

--- a/playbooks/tasks/portal-gzip-logs.yml
+++ b/playbooks/tasks/portal-gzip-logs.yml
@@ -8,7 +8,6 @@
   loop: "{{ portal_log_files }}"
   loop_control:
     loop_var: file
-  when: portal_log_files is defined
   become: True
 
 # GZIP any files over the portal_log_size_gzip_limit
@@ -22,3 +21,4 @@
     loop_var: file
     label: "{{ file.stat.path }}"
   when: file.stat.size | int > portal_log_size_gzip_limit | int
+  become: True

--- a/scripts/portals-gzip-logs.sh
+++ b/scripts/portals-gzip-logs.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Set command and arguments
+cmd=ansible-playbook
+args="--inventory /tmp/ansible-private/inventory/hosts.ini playbooks/portals-gzip-logs.yml $@"
+
+# Execute the command
+source $(dirname "$0")/lib/ansible-executor.sh


### PR DESCRIPTION
# PULL REQUEST

## Overview
Since logrotate never worked and we keep seeing disk space issues I made a helper ansible script that we can use to gzip various logs. The log files are defined with their absolute paths in the `portal_log_files` variable, so we can easily add logs. The current size trigger is 5GB which can easily be updated as well.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->
Initial test on dev1 with 1GB as the limit
<img width="571" alt="Screen Shot 2021-11-24 at 1 14 42 PM" src="https://user-images.githubusercontent.com/15232757/143294424-eea28ac6-c349-4ff6-9d77-04315a6ff32e.png">

Verified on dev3
<img width="571" alt="Screen Shot 2021-11-24 at 1 42 45 PM" src="https://user-images.githubusercontent.com/15232757/143296567-8d412fd3-e00e-430a-b9ca-cf3ab310028e.png">

<img width="723" alt="Screen Shot 2021-11-24 at 1 44 06 PM" src="https://user-images.githubusercontent.com/15232757/143296582-ea0607b5-f8aa-4c1f-8e39-0a4a9c48bf85.png">


## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
