### PR TITLE
Disable portals if free disk space is below the limit

### DIFF
--- a/changelog/items/key-updates/disable-if-low-disk-space.md
+++ b/changelog/items/key-updates/disable-if-low-disk-space.md
@@ -1,0 +1,2 @@
+- On portal deploys or restarts disable portal if free disk space is below
+  limit.

--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -152,8 +152,10 @@ skynet_js_docker_test_image: "node:14-buster-slim"
 local_temp_skynetlabs_git_repos: "/tmp/SkynetLabs-ansible/git-repos"
 local_temp_skynetlabs_git_repos_skynet_js: "{{ local_temp_skynetlabs_git_repos }}/skynet-js"
 
-# Health check disabling delay
+# Health checks
 portal_health_check_disable_delay_secs: 0
+# Disable portal when free disk space is lower then x GiB (60 GiB recommended)
+portal_health_check_disable_free_disk_space_limit_bytes: "{{ 60e+9 | int }}"
 
 # Waiting for sia full setup and /daemon/ready
 sia_full_setup_timeout_secs: 900

--- a/playbooks/tasks/portal-health-check-enable.yml
+++ b/playbooks/tasks/portal-health-check-enable.yml
@@ -1,7 +1,6 @@
 ---
 # Enable portal health check to add portal to load balancer
 
-# Check if the health check container is running
 - name: Check health check container is running
   community.docker.docker_container_info:
     name: health-check
@@ -13,6 +12,29 @@
     (health_check_docker_container_result.container is not defined) or
     (not health_check_docker_container_result.container.State.Running)
 
-# Mark the health check as enabled via the cli command
+- name: Get fresh hardware facts (incl. disk usage)
+  ansible.builtin.setup:
+    gather_subset:
+      - '!all'
+      - '!any'
+      - hardware
+
+- name: Set low disk space flag
+  set_fact:
+    # Expects webportal data to be stored on "/" mount disk
+    low_disk_space: "{{ ansible_mounts | selectattr('mount', 'equalto', '/') | map(attribute='size_available') | first | int < portal_health_check_disable_free_disk_space_limit_bytes | int }}"
+
+- block:
+    - name: Update log status to 'tested-disabled'
+      include_tasks: tasks/portal-logs-update-status.yml
+      vars:
+        tag_from: "tested"
+        tag_to: "tested-disabled"
+
+    - name: Disable portal health check to keep portal out of load balancer
+      command: docker exec health-check cli disable 'critical free disk space'
+  when: low_disk_space
+
 - name: Enable portal health check to add portal to load balancer
   command: docker exec health-check cli enable
+  when: not low_disk_space

--- a/playbooks/templates/portals-status.json.j2
+++ b/playbooks/templates/portals-status.json.j2
@@ -4,7 +4,7 @@
         {
             "title": "{{ host_vars.inventory_hostname }}",
             "description": "Ansible action: {{ portal_action }}{{ '\\n' -}}
-            {{ 'Portal is online' if (host_vars.web_result.status | default(-1) == 200) else '**Portal is not online**' }}{{ '\\n' -}}
+            {{ '**Portal is disabled**' if low_disk_space else ('Portal is online' if (host_vars.web_result.status | default(-1) == 200) else '**Portal is not online**') }}{{ '\\n' -}}
             {{ '\\n' -}}
             Portal repository:{{ '\\n' -}}
             - git tags: {{ host_vars.portal_repo_all_tags if host_vars.portal_repo_all_tags is defined else '-- failed to get the value --' }}{{ '\\n' -}}
@@ -25,7 +25,7 @@
                     + 'First 20 files:\\n'
                     + '\\n'.join(host_vars.portal_modified_files.stdout.split('\n')[:20] |  map('regex_replace', '^', '- '))
             }}",
-            "color": {{ 50782 if (host_vars.web_result.status | default(-1) == 200) else 16711680 }}
+            "color": {{ 16753920 if low_disk_space else (50782 if (host_vars.web_result.status | default(-1) == 200) else 16711680) }}
         }
     ]
 }


### PR DESCRIPTION
# PULL REQUEST

## Overview

When free disk space is below the limit we do not want to enable health checks during deploys or restarts, we set or keep the portal disabled.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
