### PR TITLE
Fix discord reporting

### DIFF
--- a/playbooks/tasks/portal-stop.yml
+++ b/playbooks/tasks/portal-stop.yml
@@ -13,3 +13,4 @@
 
 - name: Include cleaning sia renter.log file
   include_tasks: tasks/portal-logs-clean-renter-log.yml
+  when: clean_renter_log | default(False)

--- a/playbooks/templates/portals-status.json.j2
+++ b/playbooks/templates/portals-status.json.j2
@@ -4,7 +4,7 @@
         {
             "title": "{{ host_vars.inventory_hostname }}",
             "description": "Ansible action: {{ portal_action }}{{ '\\n' -}}
-            {{ '**Portal is disabled**' if low_disk_space else ('Portal is online' if (host_vars.web_result.status | default(-1) == 200) else '**Portal is not online**') }}{{ '\\n' -}}
+            {{ '**Portal is disabled**' if (low_disk_space | default(False)) else ('Portal is online' if (host_vars.web_result.status | default(-1) == 200) else '**Portal is not online**') }}{{ '\\n' -}}
             {{ '\\n' -}}
             Portal repository:{{ '\\n' -}}
             - git tags: {{ host_vars.portal_repo_all_tags if host_vars.portal_repo_all_tags is defined else '-- failed to get the value --' }}{{ '\\n' -}}
@@ -25,7 +25,7 @@
                     + 'First 20 files:\\n'
                     + '\\n'.join(host_vars.portal_modified_files.stdout.split('\n')[:20] |  map('regex_replace', '^', '- '))
             }}",
-            "color": {{ 16753920 if low_disk_space else (50782 if (host_vars.web_result.status | default(-1) == 200) else 16711680) }}
+            "color": {{ 16753920 if (low_disk_space | default(False)) else (50782 if (host_vars.web_result.status | default(-1) == 200) else 16711680) }}
         }
     ]
 }


### PR DESCRIPTION
# PULL REQUEST

## Overview

Fix for low disk reporting failure to Discord.
Add a flag to clean `renter.log` (defaults to false).

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
