### PR TITLE
Fix discord vars

### DIFF
--- a/changelog/items/other/discord-env-vars.md
+++ b/changelog/items/other/discord-env-vars.md
@@ -1,0 +1,2 @@
+- Do not include empty (undefined) discord mention vars to `.env` file. This is
+  fix for `health-checker.py` (cron script) not reporting to discord.

--- a/playbooks/templates/.env.j2
+++ b/playbooks/templates/.env.j2
@@ -85,10 +85,16 @@ AWS_SECRET_ACCESS_KEY="{{ webportal_common_config.aws_secret_access_key }}"
 
 # (optional) Only required if you're using the Discord notifications
 # integration.
+# Do not include DISCORD_MENTION_... vars if they are empty, health-checker.py
+# script will stop working.
 # TODO: Move those to common/cluster configs in LastPass
 DISCORD_WEBHOOK_URL="{{ discord_webhook_url | default('') }}"
+{% if discord_mention_role_id | default('') != '' %}
 DISCORD_MENTION_ROLE_ID="{{ discord_mention_role_id | default('') }}"
+{% endif %}
+{% if discord_mention_user_id | default('') != '' %}
 DISCORD_MENTION_USER_ID="{{ discord_mention_user_id | default('') }}"
+{% endif %}
 
 # common path for cluster, single path for each dev server
 # S3 backup path.


### PR DESCRIPTION
# PULL REQUEST

## Overview

When (`DISCORD_MENTION_ROLE_ID` was defined but) `DISCORD_MENTION_USER_ID=` was empty, `health-checker.py` script didn't report anything to discord.

This is the fix to not generate these two vars in `.env` file if their values are not defined.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
