### PR TITLE
Skylinks block performance

### DIFF
--- a/playbooks/portals-block-skylinks.yml
+++ b/playbooks/portals-block-skylinks.yml
@@ -27,32 +27,37 @@
     - name: Starting to block skylinks
       ansible.builtin.ping:
 
-    - ansible.builtin.assert:
+    - name: Assert we have defined skylinks block list (could be empty)
+      ansible.builtin.assert:
         that: skylinks_block_list is defined
         fail_msg: |
           Please define 'skylinks_block_list' variable with some skylinks to block
           or as an empty list.
           Forgot to include loading var file this way: '... -e @my-vars/skylinks-block.yml ...'?
 
-    - name: Include getting log filename prefix
-      include_tasks: tasks/portal-get-log-filename-prefix.yml
+    # Block skylinks from list
+    - block:
+        - name: Include getting log filename prefix
+          include_tasks: tasks/portal-get-log-filename-prefix.yml
 
-    - name: Set blocklist filepath
-      set_fact:
-        blocklist_filepath: "{{ logs_dir }}/{{ log_filename_prefix }}.blocklist"
+        - name: Set blocklist filepath
+          set_fact:
+            blocklist_filepath: "{{ logs_dir }}/{{ log_filename_prefix }}.blocklist"
 
-    - name: Create file with skylinks to block
-      ansible.builtin.copy:
-        dest: "{{ blocklist_filepath }}"
-        content: |
-          {% for skylink in skylinks_block_list %}
-          {{ skylink }}
-          {% endfor %}
+        - name: Create file with skylinks to block
+          ansible.builtin.copy:
+            dest: "{{ blocklist_filepath }}"
+            content: |
+              {% for skylink in skylinks_block_list %}
+              {{ skylink }}
+              {% endfor %}
 
-    # Block with file (not loop over skylinks) so that we search 
-    - name: Block skylinks via webportal blocklist script
-      ansible.builtin.command: "{{ webportal_dir }}/scripts/blocklist-skylink.sh {{ blocklist_filepath }}"
+        # Block with file (not loop over skylinks) so that we search 
+        - name: Block skylinks via webportal blocklist script
+          ansible.builtin.command: "{{ webportal_dir }}/scripts/blocklist-skylink.sh {{ blocklist_filepath }}"
+      when: skylinks_block_list | length > 0
 
+    # Block skylinks from Airtable
     - block:
         - name: Start blocking all skylinks from Airtable
           debug:

--- a/playbooks/portals-block-skylinks.yml
+++ b/playbooks/portals-block-skylinks.yml
@@ -1,8 +1,16 @@
 - name: Block Skynet Webportal Skylinks
   hosts: webportals
-  strategy: free # Execute playbook on hosts in parallel as fast as possible (do not wait for other hosts)
+  # Execute playbook on hosts in parallel as fast as possible (do not wait for
+  # other hosts), when one host is finished, next starts (limited by serial).
+  # When using free strategy without serial set, the playbook execution was
+  # clogged.
+  strategy: host_pinned
+  serial: 3
   remote_user: "{{ webportal_user }}"
   gather_facts: False
+
+  vars:
+    portal_action: "portal-skylinks-block"
 
   vars_prompt:
     - name: run_airtable
@@ -19,9 +27,31 @@
     - name: Starting to block skylinks
       ansible.builtin.ping:
 
+    - ansible.builtin.assert:
+        that: skylinks_block_list is defined
+        fail_msg: |
+          Please define 'skylinks_block_list' variable with some skylinks to block
+          or as an empty list.
+          Forgot to include loading var file this way: '... -e @my-vars/skylinks-block.yml ...'?
+
+    - name: Include getting log filename prefix
+      include_tasks: tasks/portal-get-log-filename-prefix.yml
+
+    - name: Set blocklist filepath
+      set_fact:
+        blocklist_filepath: "{{ logs_dir }}/{{ log_filename_prefix }}.blocklist"
+
+    - name: Create file with skylinks to block
+      ansible.builtin.copy:
+        dest: "{{ blocklist_filepath }}"
+        content: |
+          {% for skylink in skylinks_block_list %}
+          {{ skylink }}
+          {% endfor %}
+
+    # Block with file (not loop over skylinks) so that we search 
     - name: Block skylinks via webportal blocklist script
-      ansible.builtin.command: "{{ webportal_dir }}/scripts/blocklist-skylink.sh {{ item }}"
-      loop: "{{ skylinks_block_list | default([]) }}"
+      ansible.builtin.command: "{{ webportal_dir }}/scripts/blocklist-skylink.sh {{ blocklist_filepath }}"
 
     - block:
         - name: Start blocking all skylinks from Airtable


### PR DESCRIPTION
# PULL REQUEST

## Overview

Update skylinks block script:
- Set `host_pinned` strategy so that blocking is fast but doesn't clogg the execution.
- Allow empty blocklist to enable trigger just blocking from Airtable.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
