### PR TITLE
Add helper for shutting down a portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
             - [How to set portal, skyd, accounts versions](#how-to-set-portal-skyd-accounts-versions)
             - [How to enable parallel deployments](#how-to-enable-parallel-deployments)
             - [How to Set Deploy Batch](#how-to-set-deploy-batch)
+        - [Stop A Skynet Webportal](#stop-a-skynet-webportal)
         - [Takedown Skynet Webportal](#takedown-skynet-webportal)
             - [Playbook Actions](#playbook-actions)
             - [Preparation](#preparation)
@@ -317,6 +318,15 @@ want to divide deployment into batches, set:
 batch_size: 1
 batch_number: 1
 ```
+
+### Stop A Skynet Webportal
+
+#### Playbook Actions
+This playbook shuts down a portal by removing it from the load balancer and
+stopping all the docker services.
+
+#### Execution
+`scripts/portals-stop.sh --limit eu-ger-1`
 
 ### Takedown Skynet Webportal
 

--- a/playbooks/portals-stop.yml
+++ b/playbooks/portals-stop.yml
@@ -1,0 +1,28 @@
+- name: Stop Skynet Webportals
+  hosts: webportals
+  remote_user: "{{ webportal_user }}"
+  gather_facts: False
+
+  # Limit concurrency
+  serial: 1
+
+  # Stop on first error, do not execute on the next host
+  any_errors_fatal: True
+
+  # Playbook specific vars
+  vars:
+    max_hosts: "{{ groups['webportals'] | length - 1 }}"
+    portal_action: "portal-stop"
+
+  tasks:
+    # Check '--limit' is used
+    - name: Fail if you are targeting all dev and prod webportals
+      include_tasks: tasks/host-limit-check.yml
+
+    # Check/install Ansible prerequisities
+    - name: Include preparing portal prerequisities
+      include_tasks: tasks/portals-prepare.yml
+
+    # Disable health checks and stop docker services
+    - name: Include disabling health check and stopping portal docker services
+      include_tasks: tasks/portal-stop.yml

--- a/scripts/portals-stop.sh
+++ b/scripts/portals-stop.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Set command and arguments
+cmd=ansible-playbook
+args="--inventory /tmp/ansible-private/inventory/hosts.ini playbooks/portals-stop.yml $@"
+
+# Execute the command
+source $(dirname "$0")/lib/ansible-executor.sh


### PR DESCRIPTION
# PULL REQUEST

## Overview
Simplying pulling out the portal stop task to be executed as a single play. Helpful for migrations.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
