### PR TITLE
Fix bug in checking for uploads and downloads

### DIFF
--- a/playbooks/tasks/portal-health-check-disable.yml
+++ b/playbooks/tasks/portal-health-check-disable.yml
@@ -34,17 +34,19 @@
       ansible.builtin.command: docker exec sia siac renter uploads
       register: docker_renter_uploads
       # Wait until 'No files are uploading.' is found in the stdout. If sia is
-      # starting up for some reason, then no uploads are happening so proceed.
+      # starting up for some reason or the docker container is restarting which
+      # means sia isn't running, then no uploads are happening so proceed.
       until: >-
         docker_renter_uploads.stdout.find("No files are uploading.") != -1 or
-        docker_renter_uploads.stderr.find("490 Module not loaded") != -1
+        docker_renter_uploads.stderr.find("490 Module not loaded") != -1 or
+        docker_renter_uploads.stderr.find("restarting") != -1
       # Retry every 5 seconds for portal_upload_check_num_retries, in prod this
       # is 60 times which is where the 5 minutes is determined in the above
       # comment.
       delay: 5
       retries: "{{ portal_upload_check_num_retries }}"
-      # Only fail the task if there is an error reported to stderr, unless it is
-      # # the Module not loaded error. Otherwise we will continue on after the
+      # Only fail the task if there is an error reported to stderr, unless it
+      # is # the Module not loaded error. Otherwise we will continue on after the
       # retries are complete.
       failed_when:
         - docker_renter_uploads.stderr != ''
@@ -53,18 +55,21 @@
     - name: "Wait for downloads to finish"
       ansible.builtin.command: docker exec sia siac renter downloads
       register: docker_renter_downloads
-      # Wait until 'No files are downloading.' is found in the stdout. If sia is
-      # starting up for some reason, then no uploads are happening so proceed.
+      # Wait until 'No files are downloading.' is found in the stdout. If sia
+      # is starting up for some reason or the docker container is restarting
+      # which means sia isn't running, then no uploads are happening so
+      # proceed.
       until: >-
         docker_renter_downloads.stdout.find("No files are downloading.") != -1 or
-        docker_renter_downloads.stderr.find("490 Module not loaded") != -1
+        docker_renter_downloads.stderr.find("490 Module not loaded") != -1 or
+        docker_renter_downloads.stderr.find("restarting") != -1
       # Retry every 5 seconds for portal_download_check_num_retries, in prod
       # this is 60 times which is where the 5 minutes is determined in the above
       # comment.
       delay: 5
       retries: "{{ portal_download_check_num_retries }}"
-      # Only fail the task if there is an error reported to stderr, unless it is
-      # # the Module not loaded error. Otherwise we will continue on after the
+      # Only fail the task if there is an error reported to stderr, unless it
+      # is # the Module not loaded error. Otherwise we will continue on after the
       # retries are complete.
       failed_when:
         - docker_renter_downloads.stderr != ''

--- a/playbooks/tasks/portal-health-check-disable.yml
+++ b/playbooks/tasks/portal-health-check-disable.yml
@@ -69,7 +69,7 @@
       delay: 5
       retries: "{{ portal_download_check_num_retries }}"
       # Only fail the task if there is an error reported to stderr, unless it
-      # is # the Module not loaded error. Otherwise we will continue on after the
+      # is the Module not loaded error. Otherwise we will continue on after the
       # retries are complete.
       failed_when:
         - docker_renter_downloads.stderr != ''

--- a/playbooks/tasks/portal-health-check-disable.yml
+++ b/playbooks/tasks/portal-health-check-disable.yml
@@ -46,7 +46,7 @@
       delay: 5
       retries: "{{ portal_upload_check_num_retries }}"
       # Only fail the task if there is an error reported to stderr, unless it
-      # is # the Module not loaded error. Otherwise we will continue on after the
+      # is the Module not loaded error. Otherwise we will continue on after the
       # retries are complete.
       failed_when:
         - docker_renter_uploads.stderr != ''


### PR DESCRIPTION
# PULL REQUEST

## Overview
Added a condition to catch if the docker container is restarting when checking for uploads and downloads that are in progress.