### PR TITLE
Lower default allowance from 100KS to 10KS

### DIFF
--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -96,7 +96,7 @@ webportal_setup_dotfiles_and_dev_tools: True
 
 # TODO: move to role default vars
 webportal_allowance:
-  amount: 100KS
+  amount: 10KS
   expected_storage: 10TB
   expected_upload: 4TB
   expected_download: 2TB


### PR DESCRIPTION
# PULL REQUEST

## Overview
For new portals 100KS is too high of an initial allowance. Lowering the default in ansible to 10KS. 

I'm not putting this in the config since I don't think it is necessary out the gate for portal operators to be thinking too much about their allowance settings. Messing around with the allowance usually always causes more issues than it's worth.
