### PR TITLE
Fix host limit check for portals-deploy

### DIFF
--- a/playbooks/portals-deploy.yml
+++ b/playbooks/portals-deploy.yml
@@ -11,7 +11,7 @@
   any_errors_fatal: True
 
   vars:
-    max_hosts: "{{ groups['webportals_prod'] | length - 1 }}"
+    max_hosts: "{{ groups['webportals'] | length - 1 }}"
 
     # Default batch config (one batch with all selected hosts will be created),
     # can be overriden with cli flag --extra-vars/-e


### PR DESCRIPTION
# PULL REQUEST

## Overview

For host limit check, we can't use `webportals_prod` now, because this group might not be defined (e.g. in pro portal inventory).

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
