### PR TITLE
fix bug in health-check disable

### DIFF
--- a/playbooks/tasks/portal-health-check-disable.yml
+++ b/playbooks/tasks/portal-health-check-disable.yml
@@ -12,6 +12,13 @@
   # NOTE: portal_action is defined by the playbook, i.e. for deploys,
   # portal_action='portal-deploy'
   command: 'docker exec health-check cli disable "{{ out_of_lb_message | default(portal_action) }}"'
+  register: docker_health_check_disable_result
+  # Only fail the task if there is an error reported to stderr, unless it
+  # is that the container is restarting, since that means the health check isn't
+  # active already.
+  failed_when:
+    - docker_health_check_disable_result.stderr != ''
+    - docker_health_check_disable_result.stderr.find("restarting") == -1
   # Only execute the CLI command if the container is up and running. Otherwise,
   # if it is not up and running, it is practically disabled.
   when:


### PR DESCRIPTION
# PULL REQUEST

## Overview
Noticed a small edge case when disabling the health-check fails due to the container restarting. This shouldn't cause the ansible playbook to fail because the end result is that the health-check isn't running which is the goal.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
