### PR TITLE
remove not configurable variables

### DIFF
--- a/playbooks/templates/.env.j2
+++ b/playbooks/templates/.env.j2
@@ -219,8 +219,6 @@ STRIPE_WEBHOOK_SECRET={{ webportal_common_config.stripe_webhook_secret | default
 API_HOST=10.10.10.10
 SKYNET_ACCOUNTS_HOST=10.10.10.70
 SKYNET_ACCOUNTS_PORT=3000
-BLOCKER_HOST=blocker
-BLOCKER_PORT=4000
 
 # Sia api password. 
 #


### PR DESCRIPTION
BLOCKER_HOST and BLOCKER_PORT are not user configurable and should just be configured in docker-compose file

requires https://github.com/SkynetLabs/skynet-webportal/pull/1573
