### PR TITLE
Update getting status to run health checks

### DIFF
--- a/playbooks/tasks/portal-status-get-status.yml
+++ b/playbooks/tasks/portal-status-get-status.yml
@@ -2,53 +2,35 @@
 
 # Get portal status
 
-# Get versions files
 - name: Get versions files
   block:
-
-    # Include getting portal, Sia, accounts versions
-    - name: Include getting portal, Sia, accounts versions
+    - name: Include getting portal, skyd, accounts versions
       include_tasks: tasks/portal-versions-get.yml
-  
   rescue:
-
     - name: Getting versions failed but continue
       fail:
       failed_when: false
 
-# Get modified files
 - name: Get modified files
   block:
-
-    # Include checking for modified files after last Ansible docker services start
     - name: Include checking for modified files after last Ansible docker services start
       include_tasks: tasks/portal-repo-get-modified-files.yml
-  
   rescue:
-
     - name: Checking modified files failed but continue
       fail:
       failed_when: false
 
-# Get portal status
 - name: Get portal status
   block:
-
-    # Check loading skapp.hns webpage from the portal
-    - name: Check loading skapp.hns webpage from the portal
-      uri:
-        url: "https://skapp.hns.{{ ansible_host }}"
-        status_code: 200
-        timeout: 60
-      register: web_result
-  
+    - name: Run health checks
+      include_tasks: tasks/portal-health-checks-run.yml
   rescue:
+    - name: Recover if health checks failed and set health checks flag
+      set_fact:
+        health_checks_failed: True
+  # Exclude running health checks when they have already run
+  when: portal_action == 'portal-get-status'
 
-    - name: Recover if checking loading skapp.hns webpage from the portal failed
-      fail:
-      failed_when: false
-
-# Create json report data
 - name: Create json report data
   set_fact:
     portals_report_embeds: "{{ lookup('template', 'templates/portals-status.json.j2') }}"

--- a/playbooks/templates/portals-status.json.j2
+++ b/playbooks/templates/portals-status.json.j2
@@ -4,7 +4,7 @@
         {
             "title": "{{ host_vars.inventory_hostname }}",
             "description": "Ansible action: {{ portal_action }}{{ '\\n' -}}
-            {{ '**Portal is disabled**' if (low_disk_space | default(False)) else ('Portal is online' if (host_vars.web_result.status | default(-1) == 200) else '**Portal is not online**') }}{{ '\\n' -}}
+            {{ '**Portal is disabled**' if (low_disk_space | default(False)) else ('Portal health checks are OK' if (host_vars.health_checks_failed | default(False) != True) else '**Portal health checks are NOT OK**') }}{{ '\\n' -}}
             {{ '\\n' -}}
             Portal repository:{{ '\\n' -}}
             - git tags: {{ host_vars.portal_repo_all_tags if host_vars.portal_repo_all_tags is defined else '-- failed to get the value --' }}{{ '\\n' -}}
@@ -25,7 +25,7 @@
                     + 'First 20 files:\\n'
                     + '\\n'.join(host_vars.portal_modified_files.stdout.split('\n')[:20] |  map('regex_replace', '^', '- '))
             }}",
-            "color": {{ 16753920 if (low_disk_space | default(False)) else (50782 if (host_vars.web_result.status | default(-1) == 200) else 16711680) }}
+            "color": {{ 16753920 if (low_disk_space | default(False)) else (50782 if (host_vars.health_checks_failed | default(False) != True) else 16711680) }}
         }
     ]
 }


### PR DESCRIPTION
# PULL REQUEST

## Overview

Update getting portal status (to work with authenticated only portals):
- Get portal status using health checks.
- If health checks already run during deploy or restart - do not run them again.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
