### PR TITLE
Set default S3 backup path

### DIFF
--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -120,6 +120,7 @@ webportal_server_config_defaults:
   hsd_api_key: "{{ lookup('pipe','openssl rand -base64 32') }}"
 
 webportal_cluster_config_defaults:
+  s3_backup_path: ""
   cookie_hash_key: "{{ lookup('pipe','openssl rand -hex 32') }}"
   cookie_enc_key: "{{ lookup('pipe','openssl rand -hex 32') }}"
   skynet_db_host: "mongo"


### PR DESCRIPTION
# PULL REQUEST

## Overview

Missing `s3_backup_path` in common or cluster config in LastPass is causing issues for new portal operators.

This PR sets it default empty value.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
