### PR TITLE
Change the S3 backup dir from per-server to one common dir.

### DIFF
--- a/my-vars/config-sample-do-not-edit.yml
+++ b/my-vars/config-sample-do-not-edit.yml
@@ -24,7 +24,7 @@
 lastpass_ansible_dir: "Shared-Ansible"
 # The Following are the subfolder names of the lastpass_ansible_dir folder in
 # lastpass. The contents of these folders are controlled by ansible. Below are
-# the defaul values. You can either create these folders in LastPass or rename
+# the default values. You can either create these folders in LastPass or rename
 # these variable to the folder name you desired.
 #
 # NOTE: If you rename these variables, you should keep these variables defined
@@ -41,7 +41,7 @@ lastpass_portal_config_server_subfolder: "portal-server-configs"
 #
 # During portals-setup-following, ansible can add a list of authorized pubkeys
 # to your server. This is helpful if you are planning on managing a server with
-# a team. Ansible is set up to pull this list from a url, like a github repo. If
+# a team. Ansible is set up to pull this list from a url, like a GitHub repo. If
 # you leave the variable blank, no additional keys will be added.
 #
 # Example
@@ -56,7 +56,7 @@ webportal_user_authorized_keys: ""
 #
 # The ssl_support_email can be whatever email you would like.
 #
-# The git_checkout_email should be the email associated with your Github
+# The git_checkout_email should be the email associated with your GitHub
 # account.
 ssl_support_email: ""
 git_checkout_email: ""

--- a/playbooks/templates/.env.j2
+++ b/playbooks/templates/.env.j2
@@ -28,24 +28,24 @@
 # This is the domain that will be used for generating certificates and nginx
 # routing for cluster server together with PORTAL_DOMAIN.
 #
-# REQUIRED if different from PORTAL_DOMAIN: See top of file 
+# REQUIRED if different from PORTAL_DOMAIN: See top of file
 SERVER_DOMAIN={{ server_domain }}
 
 {% endif %}
 # A string representing name of your portal e.g. 'my-portal.com' or 'My Awesome
 # Skynet Portal' (internal use only)
 #
-# REQUIRED: Manually defined by user, or Ansible automatically generated 
+# REQUIRED: Manually defined by user, or Ansible automatically generated
 PORTAL_NAME={{ webportal_server_config.portal_name }}
 
 # Server UID to uniquelly identify the server. Used by Blocker module.
 #
-# REQUIRED: Manually defined by user, or Ansible automatically generated 
+# REQUIRED: Manually defined by user, or Ansible automatically generated
 SERVER_UID={{ webportal_server_config.server_uid }}
 
 # Sia api password.
 #
-# REQUIRED: Manually defined by user, or Ansible automatically generated 
+# REQUIRED: Manually defined by user, or Ansible automatically generated
 SIA_API_PASSWORD={{ webportal_server_config.sia_api_password }}
 
 # A list of active portal modules.
@@ -67,22 +67,22 @@ PORTAL_MODULES={{ webportal_server_config.portal_modules }}
 
 # Absolute url to the server API.
 #
-# REQUIRED: See top of file 
+# REQUIRED: See top of file
 SKYNET_SERVER_API=https://{{ server_domain }}
 
 # Sia wallet password
 #
-# REQUIRED: Ansible automatically generated 
+# REQUIRED: Ansible automatically generated
 SIA_WALLET_PASSWORD={{ webportal_server_config.sia_wallet_password if (webportal_server_config.sia_wallet_password is defined and webportal_server_config.sia_wallet_password is not none and webportal_server_config.sia_wallet_password != '') else (webportal_server_config.sia_wallet_seed if webportal_server_config.sia_wallet_seed is defined else '') }}
 
-# The port on which siad is listening, defaults to 9980. 
+# The port on which siad is listening, defaults to 9980.
 #
 # REQUIRED: manually defined by user, or default will be used
 API_PORT={{ webportal_server_config.sia_api_port }}
 
 # Auto generated secure key for your Handshake service integration.
 #
-# REQUIRED: Ansible automatically generated 
+# REQUIRED: Ansible automatically generated
 HSD_API_KEY={{ webportal_server_config.hsd_api_key }}
 
 ###############################################################################
@@ -92,12 +92,12 @@ HSD_API_KEY={{ webportal_server_config.hsd_api_key }}
 # This is the domain that will be used for generating certificates and nginx
 # routing.
 #
-# REQUIRED: See top of file 
+# REQUIRED: See top of file
 PORTAL_DOMAIN={{ cluster_domain }}
 
 # Absolute url to the (cluster) portal API.
 #
-# REQUIRED: See top of file 
+# REQUIRED: See top of file
 SKYNET_PORTAL_API=https://{{ cluster_domain }}
 
 # Administrator contact email.
@@ -126,13 +126,10 @@ DISCORD_MENTION_ROLE_ID={{ discord_mention_role_id | default('') }}
 DISCORD_MENTION_USER_ID={{ discord_mention_user_id | default('') }}
 {% endif %}
 
-# common path for cluster, single path for each dev server
 # S3 backup path.
-# For prod servers: {{ webportal_common_config.s3_backup_path }}
-# For dev servers: {{ webportal_common_config.s3_backup_path }}_<server hostname>
 #
 # OPTIONAL: manually defined by user, can be blank
-S3_BACKUP_PATH={{ webportal_common_config.s3_backup_path }}/mongo
+S3_BACKUP_PATH={{ webportal_common_config.s3_backup_path }}/{{ portal_cluster_id }}
 
 # Used to load skylinks blocklist data from Airtable
 #
@@ -152,7 +149,7 @@ SKYNET_DB_USER={{ webportal_common_config.skynet_db_user }}
 
 # MongoDB password
 #
-# REQUIRED: manually defined by user, or Ansible automatically generated 
+# REQUIRED: manually defined by user, or Ansible automatically generated
 SKYNET_DB_PASS={{ webportal_common_config.skynet_db_pass }}
 
 # MongoDB address or container name
@@ -195,7 +192,7 @@ SKYNET_ACCOUNTS_LOG_LEVEL={{ webportal_common_config.accounts_log_level }}
 ACCOUNTS_LIMIT_ACCESS={{ webportal_common_config.accounts_limit_access | string | lower }}
 
 {% if webportal_common_config.accounts_limit_access | string | lower != 'false' %}
-# Account Test account for health checks. 
+# Account Test account for health checks.
 #
 # REQUIRED when ACCOUNTS_LIMIT_ACCESS is not 'false': manually defined by user, or default will be used
 ACCOUNTS_TEST_USER_EMAIL={{ webportal_server_config.accounts_test_user_email }}

--- a/playbooks/templates/.env.j2
+++ b/playbooks/templates/.env.j2
@@ -28,20 +28,20 @@
 # This is the domain that will be used for generating certificates and nginx
 # routing.
 #
-# REQUIRED: See top of file 
+# REQUIRED: See top of file
 PORTAL_DOMAIN={{ cluster_domain }}
 
 # This is the domain that will be used for generating certificates and nginx
 # routing for cluster server together with PORTAL_DOMAIN. This domain is also
 # used by Blocker module.
 #
-# REQUIRED: See top of file 
+# REQUIRED: See top of file
 SERVER_DOMAIN={{ server_domain }}
 
 # A string representing name of your portal e.g. 'my-portal.com' or 'My Awesome
 # Skynet Portal' (internal use only)
 #
-# REQUIRED: Manually defined by user 
+# REQUIRED: Manually defined by user
 PORTAL_NAME={{ webportal_server_config.portal_name }}
 
 # A list of active portal modules.
@@ -63,22 +63,22 @@ PORTAL_MODULES={{ webportal_server_config.portal_modules }}
 
 # Absolute url to the server API.
 #
-# REQUIRED: See top of file 
+# REQUIRED: See top of file
 SKYNET_SERVER_API=https://{{ server_domain }}
 
 # Sia wallet password
 #
-# REQUIRED: Ansible automatically generated 
+# REQUIRED: Ansible automatically generated
 SIA_WALLET_PASSWORD={{ webportal_server_config.sia_wallet_password if (webportal_server_config.sia_wallet_password is defined and webportal_server_config.sia_wallet_password is not none and webportal_server_config.sia_wallet_password != '') else (webportal_server_config.sia_wallet_seed if webportal_server_config.sia_wallet_seed is defined else '') }}
 
-# The port on which siad is listening, defaults to 9980. 
+# The port on which siad is listening, defaults to 9980.
 #
 # REQUIRED: manually defined by user, or default will be used
 API_PORT={{ webportal_server_config.sia_api_port }}
 
 # Auto generated secure key for your Handshake service integration.
 #
-# REQUIRED: Ansible automatically generated 
+# REQUIRED: Ansible automatically generated
 HSD_API_KEY={{ webportal_server_config.hsd_api_key }}
 
 ###############################################################################
@@ -86,7 +86,7 @@ HSD_API_KEY={{ webportal_server_config.hsd_api_key }}
 
 # Absolute url to the (cluster) portal API.
 #
-# REQUIRED: See top of file 
+# REQUIRED: See top of file
 SKYNET_PORTAL_API=https://{{ cluster_domain }}
 
 # Administrator contact email.
@@ -120,7 +120,7 @@ DISCORD_MENTION_USER_ID={{ discord_mention_user_id | default('') }}
 # For dev servers: {{ webportal_common_config.s3_backup_path }}_<server hostname>
 #
 # OPTIONAL: manually defined by user, can be blank
-S3_BACKUP_PATH={{ webportal_common_config.s3_backup_path }}{{ '_' + inventory_hostname if 'webportals_prod' not in group_names else '' }}
+S3_BACKUP_PATH={{ webportal_common_config.s3_backup_path }}/mongo
 
 # Used to load skylinks blocklist data from Airtable
 #
@@ -140,7 +140,7 @@ SKYNET_DB_USER={{ mongodb_config.skynet_db_user }}
 
 # MongoDB password
 #
-# REQUIRED: manually defined by user, or Ansible automatically generated 
+# REQUIRED: manually defined by user, or Ansible automatically generated
 SKYNET_DB_PASS={{ mongodb_config.skynet_db_pass }}
 
 # MongoDB address or container name
@@ -164,7 +164,7 @@ SKYNET_DB_REPLICASET={{ webportal_common_config.skynet_db_replicaset }}
 
 # Absolute url to the (cluster) portal dashboard.
 #
-# REQUIRED: See top of file 
+# REQUIRED: See top of file
 SKYNET_DASHBOARD_URL=https://account.{{ cluster_domain }}
 
 # Accounts log level
@@ -189,17 +189,17 @@ ACCOUNTS_EMAIL_URI={{ webportal_common_config.accounts_email_uri }}
 
 # Domain to which your cookies will be issued
 #
-# REQUIRED: See top of file 
+# REQUIRED: See top of file
 COOKIE_DOMAIN={{ cluster_domain }}
 
 # Cookie hashing secret, at least 32 bytes
 #
-# REQUIRED: manually defined by user, or Ansible automatically generated 
+# REQUIRED: manually defined by user, or Ansible automatically generated
 COOKIE_HASH_KEY={{ webportal_common_config.cookie_hash_key }}
 
 # Cookie encryption key, at least 32 bytes
 #
-# REQUIRED: manually defined by user, or Ansible automatically generated 
+# REQUIRED: manually defined by user, or Ansible automatically generated
 COOKIE_ENC_KEY={{ webportal_common_config.cookie_enc_key }}
 
 # Stripe keys and a secret
@@ -220,9 +220,9 @@ API_HOST=10.10.10.10
 SKYNET_ACCOUNTS_HOST=10.10.10.70
 SKYNET_ACCOUNTS_PORT=3000
 
-# Sia api password. 
+# Sia api password.
 #
-# REQUIRED: manually defined by user, or Ansible automatically generated 
+# REQUIRED: manually defined by user, or Ansible automatically generated
 SIA_API_PASSWORD={{ webportal_server_config.sia_api_password }}
 
 # REQUIRED: manually defined by user, or default will be used


### PR DESCRIPTION
# PULL REQUEST

## Overview

Since our DB is cluster-wide, we don't need to backup each server individually. Moreover, the backup and restore scripts were not written to work with individual backups. That's why I'm changing the default path to be a common `mongo` dir under the S3 bucket.

PS: Sorry for the changed whitespaces - my editors are cleaning those up automatically, so I would have needed to add them back manually in order to reduce the size of the PR.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
