### PR TITLE
do not prune current docker data

### DIFF
--- a/playbooks/tasks/portal-docker-prune-old-data.yml
+++ b/playbooks/tasks/portal-docker-prune-old-data.yml
@@ -1,0 +1,11 @@
+---
+
+# Prune old docker data
+
+# TODO: Use community.docker.docker_prune with long timeout (requires
+# community.docker upgrade)
+# Prune old docker data (do not prune data produced in current build process)
+- name: Prune old docker data
+  ansible.builtin.command: docker system prune --force --filter "until=4h"
+  async: "{{ docker_prune_timeout_secs }}"
+  poll: 5

--- a/playbooks/tasks/portal-docker-services-start.yml
+++ b/playbooks/tasks/portal-docker-services-start.yml
@@ -77,11 +77,8 @@
 
       "{{ docker_compose_services }}"
 
-# Prune old docker data (do not prune data produced in current build process)
-- name: Prune docker
-  ansible.builtin.command: docker system prune --force --filter "until=4h"
-  async: "{{ docker_prune_timeout_secs }}"
-  poll: 5
+- name: Include prunning old docker data
+  include_tasks: tasks/portal-docker-prune-old-data.yml
 
 # Wait until Sia finished full setup
 - name: Wait until Sia finished full setup

--- a/playbooks/tasks/portal-docker-services-start.yml
+++ b/playbooks/tasks/portal-docker-services-start.yml
@@ -1,5 +1,4 @@
 ---
-
 # Start portal docker services
 
 # Include getting wanted docker-compose files
@@ -40,12 +39,6 @@
     mode: preserve
   loop: "{{ webportal_docker_compose_files_wanted + webportal_other_config_files }}"
 
-# Prune docker
-- name: Prune docker
-  ansible.builtin.command: docker system prune --force
-  async: "{{ docker_prune_timeout_secs }}"
-  poll: 5
-
 # Log status as 'starting'
 - name: Log status as 'starting'
   file:
@@ -81,12 +74,12 @@
   debug:
     msg: |
       Docker compose started following services:
-      
+
       "{{ docker_compose_services }}"
 
-# Prune docker
+# Prune old docker data (do not prune data produced in current build process)
 - name: Prune docker
-  ansible.builtin.command: docker system prune --force
+  ansible.builtin.command: docker system prune --force --filter "until=4h"
   async: "{{ docker_prune_timeout_secs }}"
   poll: 5
 

--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -77,14 +77,6 @@
     setup_status: "{{ setup_status_slurped.content | b64decode }}"
 
 - block:
-    # TODO: Use community.docker.docker_prune (requires community.docker
-    # upgrade) with long timeout.
-    # Prune docker
-    - name: Prune docker
-      ansible.builtin.command: docker system prune --force
-      async: "{{ docker_prune_timeout_secs }}"
-      poll: 5
-
     - name: Start Sia docker container
       community.docker.docker_compose:
         project_src: "{{ webportal_dir }}"
@@ -105,9 +97,9 @@
 
 # TODO: Use community.docker.docker_prune (requires community.docker upgrade)
 # with long timeout
-# Prune docker
+# Prune old docker data (do not prune data produced in current build process)
 - name: Prune docker
-  ansible.builtin.command: docker system prune --force
+  ansible.builtin.command: docker system prune --force --filter "until=4h"
   async: "{{ docker_prune_timeout_secs }}"
   poll: 5
 

--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -95,13 +95,8 @@
   # Don't rebuild when initializing sia with existing seed is in progress
   when: create_env_file_result.changed or sia_container_info_result.container == None or not sia_container_info_result.container.State.Running
 
-# TODO: Use community.docker.docker_prune (requires community.docker upgrade)
-# with long timeout
-# Prune old docker data (do not prune data produced in current build process)
-- name: Prune docker
-  ansible.builtin.command: docker system prune --force --filter "until=4h"
-  async: "{{ docker_prune_timeout_secs }}"
-  poll: 5
+- name: Include prunning old docker data
+  include_tasks: tasks/portal-docker-prune-old-data.yml
 
 - name: Check wallet
   command: docker exec sia siac wallet


### PR DESCRIPTION
- completely drop pruning docker data **before** rebuilding containers - we want to leverage build cache to speed up the process
- **after** rebuilding, prune only docker data that is more than 4 hours old (arbitrary number but should be good enough) which means it will keep docker data that was produced during current build process

Originally we added strict pruning before and after because we were running out of disk space during deploys due to issues with cache, small disks on some machines, log files overflow etc. Also with every rebuild, docker data kept growing and I didn't know there was an option to prune just old data. I think we're in a quite good position to keep just current docker data now and it should significantly improve build times on deploys.

Let's test it @firyx :)