### PR TITLE
Set default values

### DIFF
--- a/changelog/items/key-updates/default-setup-flags.md
+++ b/changelog/items/key-updates/default-setup-flags.md
@@ -1,0 +1,1 @@
+- Set default setup flags for community portal operators.

--- a/my-vars/config-sample-do-not-edit.yml
+++ b/my-vars/config-sample-do-not-edit.yml
@@ -1,5 +1,6 @@
 # This config file can be used to set any ansible variables needed to execute
-# necessary ansible playbooks.
+# necessary ansible playbooks. These settings when used will also override
+# values defined in playbooks/group_vars/webportals.yml.
 
 ###############################################################################
 # REQUIRED
@@ -7,6 +8,31 @@
 # Below are a list of variables that require attention if the defaults are not
 # suitable.
 ###############################################################################
+
+###############################################################################
+# Server Setup
+#
+# Ansible script to setup and later to update portal server
+# (portal-setup-following)
+#
+# Enable fail2ban (default False, recommended: True)
+security_fail2ban_enabled: False
+#
+# Set server timezone (default: False)
+# Based on your system, e.g. UTC timezone should be set as "UTC" or "Etc/UTC"
+webportal_server_set_timezone: False
+webportal_server_timezone: "UTC"
+#
+# Update server hostname (default: False)
+# The script will update server hostname to Ansible inventory_hostname as
+# defined in your inventory/hosts.ini (to e.g.: "skynet-node-01")
+webportal_update_hostname: False
+#
+# Some services used to scan local networks, so according to server providers'
+# advice operators can disable outgoing traffic to local networks. This might
+# disrupt existing services (other than skynet portal stack) on the server.
+ufw_deny_outgoing_to_local_network: False
+
 
 ###############################################################################
 # LastPass

--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -18,14 +18,14 @@ initial_users:
 # geerlingguy.security role vars
 security_sudoers_passworded: "{{ [webportal_user] }}"
 security_autoupdate_enabled: False
-security_fail2ban_enabled: True
+security_fail2ban_enabled: False
 
 # Server settings
 # Timezone
-webportal_server_set_timezone: True
+webportal_server_set_timezone: False
 webportal_server_timezone: "UTC"
 # Update server hostname to inventory hostname
-webportal_update_hostname: True
+webportal_update_hostname: False
 
 # geerlingguy.docker role vars
 docker_users: "{{ [webportal_user] }}"
@@ -34,7 +34,7 @@ docker_users: "{{ [webportal_user] }}"
 group_ufw_rules:
   - { rule: "allow", port: "80", proto: "tcp", direction: "in" }
   - { rule: "allow", port: "443", proto: "tcp", direction: "in" }
-ufw_deny_outgoing_to_local_network: True
+ufw_deny_outgoing_to_local_network: False
 local_networks_allowed:
   - "10.10.10.10/24"
 local_networks_denied:


### PR DESCRIPTION
# PULL REQUEST

## Overview

Portal setup scripts used to setup additional toools or settings on portal servers according to Skynet Labs needs. Like:
- ufw firewall
- blocking outgoing traffic to local networks
- timezone
- dotfiles
- dev tools
- ...
These defaults might not be desired by community portal operators, they might want to run alternative tools or they might want to run other services than just skynet webportal stack.

This PR makes all these settings optional, turned off by default.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
