### PR TITLE
Parallel dirs

### DIFF
--- a/changelog/items/other/ansiblecm-stop.md
+++ b/changelog/items/other/ansiblecm-stop.md
@@ -1,0 +1,1 @@
+- Add script to stop Ansible Control Machine.

--- a/changelog/items/other/lastpass-login-no-restart.md
+++ b/changelog/items/other/lastpass-login-no-restart.md
@@ -1,0 +1,1 @@
+- Login to LastPass doesn't restarts Ansible CM container.

--- a/changelog/items/other/parallel-dirs.md
+++ b/changelog/items/other/parallel-dirs.md
@@ -1,0 +1,1 @@
+- Allow parallel execution of playbooks in different directories.

--- a/scripts/ansiblecm-stop.sh
+++ b/scripts/ansiblecm-stop.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Set command and arguments
+cmd=
+args=
+stop_ansiblecm=true
+
+# Execute the command
+source $(dirname "$0")/lib/ansible-executor.sh

--- a/scripts/lastpass-login.sh
+++ b/scripts/lastpass-login.sh
@@ -9,7 +9,6 @@ read -p "Enter desired LastPass timeout in seconds (empty for default $default_l
 # Set command and arguments
 cmd=lpass
 args="login $lpass_username"
-restart_ansible_cm=true
 
 # Execute the command
 source $(dirname "$0")/lib/ansible-executor.sh

--- a/scripts/lib/ansible-executor.sh
+++ b/scripts/lib/ansible-executor.sh
@@ -43,7 +43,8 @@ if [ -z "$lpass_timeout" ]; then
   lpass_timeout=$default_lpass_timeout_secs
 fi
 
-# Check if wanted image runs for the given directory
+# Check: We don't want to stop ansible CM && given playbooks directory runs
+# wanted ansible image
 if [ "$stop_ansiblecm" != "true" ] && docker ps -a --no-trunc --format "table {{.Image}} {{.Names}}" | grep "^$ansiblecm_image $ansiblecm_container$" > /dev/null; then
   echo "Ansible Control Machine with container name: $ansiblecm_container is already running"
 else
@@ -53,6 +54,8 @@ else
   # - stop containers if found
   echo "Stopping Ansible Control Machine with container name: $ansiblecm_container (if running)..."
   docker ps -a --no-trunc --format "table {{.Names}}" | grep "^$ansiblecm_container$" | xargs -r docker stop > /dev/null
+
+  # If ansible CM stop playbook was executed, we are done
   if [ "$stop_ansiblecm" == "true" ]; then
     echo "Ansible Control Machine with container name: $ansiblecm_container is stopped"
     exit 0

--- a/scripts/lib/ansible-executor.sh
+++ b/scripts/lib/ansible-executor.sh
@@ -44,7 +44,7 @@ if [ -z "$lpass_timeout" ]; then
 fi
 
 # Check if wanted image runs for the given directory
-if docker ps -a --no-trunc --format "table {{.Image}} {{.Names}}" | grep "^$ansiblecm_image $ansiblecm_container$" > /dev/null; then
+if [ "$stop_ansiblecm" != "true" ] && docker ps -a --no-trunc --format "table {{.Image}} {{.Names}}" | grep "^$ansiblecm_image $ansiblecm_container$" > /dev/null; then
   echo "Ansible Control Machine with container name: $ansiblecm_container is already running"
 else
   # Stop Ansible containers running on older/non-wanted docker images
@@ -53,6 +53,10 @@ else
   # - stop containers if found
   echo "Stopping Ansible Control Machine with container name: $ansiblecm_container (if running)..."
   docker ps -a --no-trunc --format "table {{.Names}}" | grep "^$ansiblecm_container$" | xargs -r docker stop > /dev/null
+  if [ "$stop_ansiblecm" == "true" ]; then
+    echo "Ansible Control Machine with container name: $ansiblecm_container is stopped"
+    exit 0
+  fi
 
   # Start Ansible Control Machine and keep it running. This is especially
   # needed for LastPass session.

--- a/scripts/lib/ansible-executor.sh
+++ b/scripts/lib/ansible-executor.sh
@@ -28,25 +28,30 @@ pushd $ans_dir > /dev/null
 
 # Configs
 # Current Ansible Control Machine image
-ansible_image='skynetlabs/ansiblecm:ansible-3.1.0-skynetlabs-0.7.0'
+ansiblecm_image='skynetlabs/ansiblecm:ansible-3.1.0-skynetlabs-0.7.0'
+
+# To allow running 2 or more parallel ansiblecm containers running from
+# different directories (having mounted different directories) we need to
+# distinguish them via docker container postfix. Postfix is based on the
+# checksum of the current ansible playbooks directory.
+container_postfix=$(docker run alpine sh -c "echo '$ans_dir' | cksum | cut -d ' ' -f 1")
+ansiblecm_container=ansiblecm-$container_postfix
 
 # Set LastPass session timeout
 if [ -z "$lpass_timeout" ]; then
   lpass_timeout=$default_lpass_timeout_secs
 fi
 
-# Check if we want to restart Ansible CM logging to LastPass or updating wanted image
-if [ "$restart_ansible_cm" != true ] && docker ps | grep "\s$ansible_image\s" > /dev/null; then
-  echo "Ansible Control Machine is running"
+# Check if wanted image runs for the given directory
+if docker ps -a --no-trunc --format "table {{.Image}} {{.Names}}" | grep "^$ansiblecm_image $ansiblecm_container$" > /dev/null; then
+  echo "Ansible Control Machine is already running"
 else
-  echo "Stopping Ansible Control Machine..."
-
-  # Stop older/non-wanted Ansible container versions if running
-  # - list all running docker containers
-  # - get only ansible control machines
-  # - get container id
+  # Stop Ansible containers running on older/non-wanted docker images
+  # - list all docker container names
+  # - get only ansible control machines (belonging to this ansible playbooks directory)
   # - stop containers if found
-  docker ps -a | grep ansiblecm | awk '{print $1;}' | xargs -r docker stop > /dev/null
+  echo "Stopping Ansible Control Machine (if running)..."
+  docker ps -a --no-trunc --format "table {{.Names}}" | grep "^$ansiblecm_container$" | xargs -r docker stop > /dev/null
 
   # Start current version
   echo "Starting Ansible Control Machine..."
@@ -69,8 +74,8 @@ else
     -v /var/run/docker.sock:/var/run/docker.sock \
     --env SSH_AUTH_SOCK=/ssh-agent \
     --detach \
-    --name ansiblecm \
-    $ansible_image \
+    --name $ansiblecm_container \
+    $ansiblecm_image \
     infinity > /dev/null
 fi
 
@@ -89,7 +94,7 @@ if [ "$requirements_installed" = "$requirements_commit" ]; then
     echo "Ansible requirements (roles and collections) are up-to-date"
 else
     echo "Updating Ansible requirements (roles and collections)..."
-    docker exec ansiblecm ansible-galaxy install -r requirements.yml --force
+    docker exec $ansiblecm_container ansible-galaxy install -r requirements.yml --force
     echo $requirements_commit > $requirements_installed_file
 fi
 
@@ -98,4 +103,4 @@ echo "Executing:"
 echo "    $cmd $args"
 echo "in a docker container..."
 
-docker exec -it ansiblecm $cmd $args
+docker exec -it $ansiblecm_container $cmd $args

--- a/scripts/lib/ansible-executor.sh
+++ b/scripts/lib/ansible-executor.sh
@@ -33,8 +33,9 @@ ansiblecm_image='skynetlabs/ansiblecm:ansible-3.1.0-skynetlabs-0.7.0'
 # To allow running 2 or more parallel ansiblecm containers running from
 # different directories (having mounted different directories) we need to
 # distinguish them via docker container postfix. Postfix is based on the
-# checksum of the current ansible playbooks directory.
-container_postfix=$(docker run alpine sh -c "echo '$ans_dir' | cksum | cut -d ' ' -f 1")
+# checksum of the absolute path of the current ansible playbooks directory.
+wd=$(pwd)
+container_postfix=$(docker run alpine sh -c "echo '$wd' | cksum | cut -d ' ' -f 1")
 ansiblecm_container=ansiblecm-$container_postfix
 
 # Set LastPass session timeout
@@ -44,17 +45,14 @@ fi
 
 # Check if wanted image runs for the given directory
 if docker ps -a --no-trunc --format "table {{.Image}} {{.Names}}" | grep "^$ansiblecm_image $ansiblecm_container$" > /dev/null; then
-  echo "Ansible Control Machine is already running"
+  echo "Ansible Control Machine with container name: $ansiblecm_container is already running"
 else
   # Stop Ansible containers running on older/non-wanted docker images
   # - list all docker container names
   # - get only ansible control machines (belonging to this ansible playbooks directory)
   # - stop containers if found
-  echo "Stopping Ansible Control Machine (if running)..."
+  echo "Stopping Ansible Control Machine with container name: $ansiblecm_container (if running)..."
   docker ps -a --no-trunc --format "table {{.Names}}" | grep "^$ansiblecm_container$" | xargs -r docker stop > /dev/null
-
-  # Start current version
-  echo "Starting Ansible Control Machine..."
 
   # Start Ansible Control Machine and keep it running. This is especially
   # needed for LastPass session.
@@ -62,6 +60,7 @@ else
   # forwarding from local machine (a docker host machine) to Ansible Control
   # Machine in docker which can then perform SSH agent forwarding between
   # remote hosts.
+  echo "Starting Ansible Control Machine with container name: $ansiblecm_container..."
   docker run -it --rm \
     --entrypoint sleep \
     -e ANSIBLE_STDOUT_CALLBACK=debug \
@@ -86,21 +85,21 @@ requirements_commit=$(git log -n 1 --pretty=format:%H -- requirements.yml)
 # Get the git commit of the latest installed requirements
 requirements_installed_file=my-logs/requirements-installed.txt
 if [ -f "$requirements_installed_file" ]; then
-    requirements_installed=$(cat $requirements_installed_file)
+  requirements_installed=$(cat $requirements_installed_file)
 fi
 
 # Install requirements
 if [ "$requirements_installed" = "$requirements_commit" ]; then
-    echo "Ansible requirements (roles and collections) are up-to-date"
+  echo "Ansible requirements (roles and collections) are up-to-date"
 else
-    echo "Updating Ansible requirements (roles and collections)..."
-    docker exec $ansiblecm_container ansible-galaxy install -r requirements.yml --force
-    echo $requirements_commit > $requirements_installed_file
+  echo "Updating Ansible requirements (roles and collections)..."
+  docker exec $ansiblecm_container ansible-galaxy install -r requirements.yml --force
+  echo $requirements_commit > $requirements_installed_file
 fi
 
 # Execute the playbook from Ansible CM in a Docker container
 echo "Executing:"
 echo "    $cmd $args"
-echo "in a docker container..."
+echo "in a docker container $ansiblecm_container..."
 
 docker exec -it $ansiblecm_container $cmd $args


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR fixes some playbooks operations issues:
- Login to LastPass now doesn't restarts Ansible CM container (running playbooks e.g. deploys are not affected by LastPass login).
- Running parallel playbooks from different Ansible playbooks directories (e.g. regular and skynetpro.net) on the same machine are allowed (no need to stop the other directory Ansible CM container).

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
