### PR TITLE
Remove obsolete Sia API password setting from serverlist script

### DIFF
--- a/playbooks/x-portals-setup-serverlist.yml
+++ b/playbooks/x-portals-setup-serverlist.yml
@@ -53,7 +53,6 @@
         path: "{{ webportal_dir }}/.env"
         marker: "# {mark} - {{ serverlist_marker }} (https://github.com/SkynetLabs/servers)"
         block: |
-          SIA_API_PASSWORD={{ sia_api_password_result.stdout }}
           SERVERLIST_ENTROPY={{ webportal_common_config.serverlist_entropy }}
           SERVERLIST_TWEAK={{ webportal_common_config.serverlist_tweak }}
           SERVERLIST_SKYD=10.10.10.10:9980


### PR DESCRIPTION
# PULL REQUEST

## Overview

Script setting serverlist used `SIA_API_PASSWORD` stored in a file, while skyd was updated to get the value from `.env` file.
This PR removed obsolete and incorrect setting of this variable.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
