### PR TITLE
Remove Consensus Sync Block from Setup Following

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,9 @@ Server aliases (`eu-ger-1`, `us-pa-1`, ...) are stored in `inventory/hosts.ini`.
 - Starts docker compose services.
 - Waits for Sia full setup finished.
 - Waits for Sia `/daemon/ready` (if the endpoint is available).
+- Waits for Sia Blockchain to be synced.
 - Runs portal integration tests.
+- Runs portal health check.
 - Enables health check.
 
 For logs see above Playbook: Restart Skynet Webportal.
@@ -608,17 +610,10 @@ Playbook:
   - Always recreate `.env` file from `.env.j2` template and portal config
   - Start sia container if not running, restart if config changed
   - Init new wallet (if not done previously)
-  - Wait for sia blockchain synced (takes time, can timeout)
   - Init wallet (with existing seed if exists, takes time, can timeout)
   - Unlock wallet
   - Set default allowance
   - Setup health checks
-
-Timeouts:  
-This playbook is expected to fail with a timeout (might be a couple of times).
-Timeouts are handled gracefully and next steps are described in ansible logs
-onscreen. Follow the instructions from the onscreen logs and restart the
-playbook when ready.
 
 Execute (e.g. on `eu-fin-5`):
 `scripts/portals-setup-following.sh -e @my-vars/config.yml --limit eu-fin-5`
@@ -627,6 +622,10 @@ Execute (e.g. on `eu-fin-5`):
 
 To finish portal setup and deployment execute portal deploy playbook (see
 separate section above).
+
+**NOTE** You should give your node enough time to sync the Sia blockchain and
+*form file contracts before running the deploy script. Otherwise the health
+*checks will fail as your node is not ready to upload and download
 
 ### Run Docker Command
 

--- a/changelog/items/key-updates/remove-cs-sync-block.md
+++ b/changelog/items/key-updates/remove-cs-sync-block.md
@@ -1,0 +1,2 @@
+- Remove block for synced consensus in `portals-setup-following`
+- Add block for synced consensus in `portal-docker-services-start`

--- a/playbooks/tasks/portal-docker-services-start.yml
+++ b/playbooks/tasks/portal-docker-services-start.yml
@@ -88,6 +88,28 @@
   delay: 1
   retries: "{{ sia_full_setup_timeout_secs }}"
 
+# Check that the Sia Blockchain is synced
+- name: Check Sia blockchain sync status
+  command: docker exec sia siac consensus
+  register: siac_consensus_result
+  until: "'Synced: Yes' in siac_consensus_result.stdout"
+  delay: 30
+  retries: 20
+  failed_when: False
+
+- name: Check if the Sia blockchain is synced
+  fail:
+    msg: |
+      Sia blockchain is not yet synced:
+
+      {{ siac_consensus_result.stdout }}
+
+      Wait for Sia blockchain synced and rerun the playbook.
+      To check sync status, execute (on the server):
+
+        docker exec sia siac consensus
+  when: "'Synced: Yes' not in siac_consensus_result.stdout"
+
 # Include waiting for sia daemon/ready
 - name: Include waiting for sia daemon/ready
   include_tasks: tasks/portal-wait-for-sia-daemon-ready.yml

--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -114,27 +114,6 @@
   set_fact:
     sia_wallet_seed_defined: "{{ webportal_server_config.sia_wallet_seed is defined }}"
 
-- name: Check Sia blockchain sync status
-  command: docker exec sia siac consensus
-  register: siac_consensus_result
-  until: "'Synced: Yes' in siac_consensus_result.stdout"
-  delay: 30
-  retries: 20
-  failed_when: False
-
-- name: Check if the Sia blockchain is synced
-  fail:
-    msg: |
-      Sia blockchain is not yet synced:
-
-      {{ siac_consensus_result.stdout }}
-
-      Wait for Sia blockchain synced and rerun the playbook.
-      To check sync status, execute (on the server):
-
-        docker exec sia siac consensus
-  when: "'Synced: Yes' not in siac_consensus_result.stdout"
-
 # Init a wallet with existing seed
 
 # TODO: (2nd appearance) unite Load and Get into a role task: load portal setup status


### PR DESCRIPTION
# PULL REQUEST

## Overview
This PR removes the consensus being synced as a blocker in the `portals-setup-following`. The rational is that after setup-following you still need to send siacoins to the wallet and wait for contracts to form anyways. Additionally there is nothing in the remainder of setup-following that requires the consensus to be synced.

Instead, the consensus sync check has been added to the docker services start task so that we ensure consensus is synced at the end of a deploy. 

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
