### PR TITLE
Fix Ansible become/sudo issues

### DIFF
--- a/changelog/items/bugs-fixed/reset-ssh.md
+++ b/changelog/items/bugs-fixed/reset-ssh.md
@@ -1,2 +1,2 @@
 - Reset SSH connection in `portal-setup-following` to fix (frequent) issue with
-  privilege escalation (become: True => `Incorrect become password.`)
+  privilege escalation (`become: True` => `Incorrect become password.`)

--- a/changelog/items/bugs-fixed/reset-ssh.md
+++ b/changelog/items/bugs-fixed/reset-ssh.md
@@ -1,0 +1,2 @@
+- Reset SSH connection in `portal-setup-following` to fix (frequent) issue with
+  privilege escalation (become: True => `Incorrect become password.`)

--- a/playbooks/portals-setup-following.yml
+++ b/playbooks/portals-setup-following.yml
@@ -50,6 +50,10 @@
 
     # Stop docker services gracefully - end
 
+    - name: Reset SSH connection to fix occasional Ansible become/sudo issues
+      ansible.builtin.meta:
+        reset_connection
+
     - name: Include basic security setup
       include_tasks: tasks/basic-security-setup.yml
       args:


### PR DESCRIPTION
# PULL REQUEST

## Overview

When running `portal-setup-following` after `portal-setup-initial` we often get issues with Ansible become password (password not valid).

Debugging showed, that password is correctly read from LastPass and set in the playbook, manual login with the password succeeds.

I suspect that the issue is caused by Ansible multiplexing SSH connections (together with user switching done by playbooks), so I try to fix this by resetting SSH connection during playbook execution.

With this change I couldn't repeat the issue previously encountered on freshly set/reset host, so it might have been solved by this PR.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
