### PR TITLE
Add max contract and sector access prices to defaults

### DIFF
--- a/changelog/items/key-updates/allowance-updates.md
+++ b/changelog/items/key-updates/allowance-updates.md
@@ -1,0 +1,1 @@
+- Added `max_contract_price` and `max_sector_access_price` to default allowance

--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -117,6 +117,8 @@ webportal_allowance:
   expected_upload: 4TB
   expected_download: 2TB
   expected_redundancy: 5
+  max_contract_price: 1SC
+  max_sector_access_price: 5SC
   max_storage_price: 300SC
   payment_contract_initial_funding: 10SC
   period: 8640b

--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -249,6 +249,8 @@
       --expected-upload {{ webportal_allowance.expected_upload }}
       --expected-download {{ webportal_allowance.expected_download }}
       --expected-redundancy {{ webportal_allowance.expected_redundancy }}
+      --max-contract-price {{ webportal_allowance.max_contract_price }}
+      --max-sector-access-price {{ webportal_allowance.max_sector_access_price }}
       --max-storage-price {{ webportal_allowance.max_storage_price }}
       --payment-contract-initial-funding {{ webportal_allowance.payment_contract_initial_funding }}
       --period {{ webportal_allowance.period }}


### PR DESCRIPTION
# PULL REQUEST

## Overview
Added `max_contract_price` and `max_sector_access_price` to default allowance settings based on discord discussion.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
