### PR TITLE
remove docker compose orphaned services on deploy

### DIFF
--- a/playbooks/portals-takedown.yml
+++ b/playbooks/portals-takedown.yml
@@ -47,6 +47,7 @@
         project_src: "{{ webportal_dir }}"
         files: "{{ webportal_docker_compose_files_wanted }}"
         build: False
+        remove_orphans: True
         nocache: True
         pull: True
         services: sia

--- a/playbooks/tasks/portal-docker-services-start.yml
+++ b/playbooks/tasks/portal-docker-services-start.yml
@@ -56,6 +56,7 @@
     project_src: "{{ webportal_dir }}"
     files: "{{ webportal_docker_compose_files_wanted }}"
     build: "{{ docker_compose_build }}"
+    remove_orphans: True
     nocache: False
     pull: True
     state: present


### PR DESCRIPTION
adds `--remove-orphans` on deploy, useful when:
- we changed container name of one service and want to clean up the old service on restart
- we changed PORTAL_MODULES and want to clean up services not needed any more on the server