### PR TITLE
Add handling for different path separators for lastpass

### DIFF
--- a/changelog/items/bugs-fixed/personal-laspass-handling.md
+++ b/changelog/items/bugs-fixed/personal-laspass-handling.md
@@ -1,0 +1,1 @@
+- Add handling for personal lastpass accounts with the different path separator for folders.

--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -52,8 +52,23 @@ local_networks_denied:
 # LastPass settings
 lastpass_ansible_dir: "Shared-Ansible"
 
+# lastpass has different separators based on the account. Because that makes
+# total sense and everyone's lives easier. The file separator is defined as the
+# path separator between a directory and file, i.e. dir/file. The directory
+# separator is the path separator between directories, i.e. dir/subdir.
+#
+# The file separator appears to always be a forward slash /
+#
+# The directory separator appears to change based on Shared folders for business
+# accounts and folders for personal accounts. Ansible uses the lpass cli tool,
+# and the lpass cli tool shows a path separator of a forward slash / for Shared
+# folders under business accounts and shows a path separator of a double back
+# slash \\ for personal folders.
+lastpass_directory_separator: '{{ "/" if "Shared" in lastpass_ansible_dir else "\\" }}'
+lastpass_file_separator: "/"
+
 lastpass_portal_credentials_server_subfolder: "portal-server-credentials"
-lastpass_portal_credentials_server: "{{ lastpass_ansible_dir }}/{{ lastpass_portal_credentials_server_subfolder }}/{{ webportal_user + '@' + ansible_host }}"
+lastpass_portal_credentials_server: "{{ lastpass_ansible_dir }}{{ lastpass_directory_separator }}{{ lastpass_portal_credentials_server_subfolder }}{{ lastpass_file_separator }}{{ webportal_user + '@' + ansible_host }}"
 
 lastpass_portal_config_common_subfolder: "portal-common-configs"
 lastpass_portal_config_cluster_subfolder: "portal-cluster-configs"
@@ -61,12 +76,12 @@ lastpass_portal_config_cluster_subfolder: "portal-cluster-configs"
 # See my-vars/config-sample-do-not-edit.yml file for documentation.
 lastpass_portal_common_and_cluster_configs_list:
   # - "{{ lastpass_ansible_dir }}/{{ lastpass_portal_config_common_subfolder }}/common.yml"
-  - "{{ lastpass_ansible_dir }}/{{ lastpass_portal_config_cluster_subfolder }}/cluster-{{ portal_cluster_id }}.yml"
+  - "{{ lastpass_ansible_dir }}{{ lastpass_directory_separator }}{{ lastpass_portal_config_cluster_subfolder }}{{ lastpass_file_separator }}cluster-{{ portal_cluster_id }}.yml"
 
 lastpass_portal_config_server_subfolder: "portal-server-configs"
-lastpass_portal_config_server: "{{ lastpass_ansible_dir }}/{{ lastpass_portal_config_server_subfolder }}/{{ inventory_hostname }}.yml"
+lastpass_portal_config_server: "{{ lastpass_ansible_dir }}{{ lastpass_directory_separator }}{{ lastpass_portal_config_server_subfolder }}{{ lastpass_file_separator }}{{ inventory_hostname }}.yml"
 
-lastpass_accounts_jwks_json: "{{ lastpass_ansible_dir }}/{{ lastpass_portal_config_cluster_subfolder }}/cluster-{{ portal_cluster_id }}-jwks.json"
+lastpass_accounts_jwks_json: "{{ lastpass_ansible_dir }}{{ lastpass_directory_separator }}{{ lastpass_portal_config_cluster_subfolder }}{{ lastpass_file_separator }}cluster-{{ portal_cluster_id }}-jwks.json"
 
 # Portal paths settings
 webportal_user_home_dir: "/home/{{ webportal_user }}"

--- a/playbooks/portals-setup-following.yml
+++ b/playbooks/portals-setup-following.yml
@@ -20,7 +20,7 @@
         fail_msg: "{{ ansible_distribution }} {{ ansible_distribution_version }} is not yet supported by this role"
 
     # Stop docker services gracefully - begin
-    
+
     # If we rerun this playbook on any server which successfully started up
     # docker services, we need to stop them gracefully (wait for uploads/
     # downloads to finish) first before we continue with server setup, because
@@ -56,8 +56,7 @@
     # Stop docker services gracefully - end
 
     - name: Reset SSH connection to fix occasional Ansible become/sudo issues
-      ansible.builtin.meta:
-        reset_connection
+      ansible.builtin.meta: reset_connection
 
     - name: Include basic security setup
       include_tasks: tasks/basic-security-setup.yml
@@ -173,6 +172,8 @@
 
       when: webportal_setup_dotfiles_and_dev_tools
 
+    # REMOVE!!
+    - meta: end_host
     - name: Include role to setup Skynet Webportal
       include_role:
         name: skynetlabs.skynet_webportal

--- a/playbooks/portals-setup-following.yml
+++ b/playbooks/portals-setup-following.yml
@@ -172,8 +172,6 @@
 
       when: webportal_setup_dotfiles_and_dev_tools
 
-    # REMOVE!!
-    - meta: end_host
     - name: Include role to setup Skynet Webportal
       include_role:
         name: skynetlabs.skynet_webportal

--- a/playbooks/tasks/lastpass-load-json-note.yml
+++ b/playbooks/tasks/lastpass-load-json-note.yml
@@ -26,7 +26,12 @@
 - name: Check if LastPass item exists
   local_action:
     module: ansible.builtin.command
-    cmd: "lpass ls --sync now {{ item.lastpass_path }}"
+    # NOTE: We use single quotes around the lastpass paths to ensure the path
+    # separators are not escaped. This is specific handling due to the path
+    # being passed in as a variable to this task. The single quotes wouldn't be
+    # needed if the variable was accessed directly, i.e
+    # lastpass_portal_config_server
+    cmd: "lpass ls --sync now '{{ item.lastpass_path }}'"
   register: lastpass_ls_result
   changed_when: False
 

--- a/playbooks/tasks/lastpass-load-webportal-config.yml
+++ b/playbooks/tasks/lastpass-load-webportal-config.yml
@@ -1,5 +1,4 @@
 ---
-
 # Load portal configs from LastPass
 
 # Load server config
@@ -22,7 +21,7 @@
   loop: "{{ lastpass_portal_common_and_cluster_configs_list }}"
   loop_control:
     index_var: config_index
-  
+
 - name: Include loading common/cluster configs from LastPass
   include_tasks: tasks/lastpass-load-yaml-note.yml
   loop: "{{ lastpass_common_cluster_configs }}"

--- a/playbooks/tasks/lastpass-load-yaml-note.yml
+++ b/playbooks/tasks/lastpass-load-yaml-note.yml
@@ -26,7 +26,12 @@
 - name: Check if LastPass item exists
   local_action:
     module: ansible.builtin.command
-    cmd: "lpass ls --sync now {{ item.lastpass_path }}"
+    # NOTE: We use single quotes around the lastpass paths to ensure the path
+    # separators are not escaped. This is specific handling due to the path
+    # being passed in as a variable to this task. The single quotes wouldn't be
+    # needed if the variable was accessed directly, i.e
+    # lastpass_portal_config_server
+    cmd: "lpass ls --sync now '{{ item.lastpass_path }}'"
   register: lastpass_ls_result
   changed_when: False
 

--- a/playbooks/tasks/lastpass-save-user-credentials.yml
+++ b/playbooks/tasks/lastpass-save-user-credentials.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Check if webportal user credentials LastPass record exists
   local_action:
     module: ansible.builtin.command

--- a/playbooks/tasks/lastpass-save-webportal-config.yml
+++ b/playbooks/tasks/lastpass-save-webportal-config.yml
@@ -1,5 +1,4 @@
 ---
-
 # Server config
 
 - name: Check if LastPass server record exists
@@ -17,7 +16,6 @@
     module: shell
     cmd: printf '{{ webportal_server_config | to_nice_yaml(width=2048) }}' | lpass {{ lastpass_command }} --sync now --notes --non-interactive {{ lastpass_portal_config_server }}
   no_log: True
-
 # TODO: Saving missing cluster variables
 # Common/cluster config
 


### PR DESCRIPTION
# PULL REQUEST

## Overview
This PR adds handling of the different path separators for LastPass directories between shared folders and personal folders. Since shared folders have the prefix `Shared`, we can easily set the separator based on the top level folder name.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->
Terminal Output proof:

https://hackmd.io/so0iuxfgQxe2mQwhasrB8Q

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
