### PR TITLE
Expand set-allowance-max-storage-price 

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,8 +388,8 @@ To check `eu-ger-1`, `us-pa-1` and `us-va-1` portals:
 Playbook:
 
 - Sets allowance defined in
-  `playbooks/portals-set-allowance-max-storage-price.yml` > `vars` >
-  `max_storage_price`
+  `playbooks/portals-set-allowance-price-controls.yml` > `vars` >
+  `max_storage_price`, `max_contract_price`, `max_sector_access_price`
   on the portal server(s).
 
 Notes:
@@ -400,8 +400,8 @@ Notes:
   `docker exec sia siac renter setallowance --max-storage-price`
 
 To run:  
-`scripts/portals-set-allowance-max-storage-price.sh --limit webportals_prod`  
-`scripts/portals-set-allowance-max-storage-price.sh --limit eu-ger-3`
+`scripts/portals-set-allowance-price-controls.sh --limit webportals_prod`  
+`scripts/portals-set-allowance-price-controls.sh --limit eu-ger-3`
 
 ### Block Portal Skylinks
 

--- a/README.md
+++ b/README.md
@@ -383,7 +383,8 @@ To check `eu-ger-1` portal:
 To check `eu-ger-1`, `us-pa-1` and `us-va-1` portals:
 `scripts/portals-get-versions.sh --limit eu-ger-1,us-pa-1,us-va-1`
 
-### Set Allowance Max Storage Price
+### Set Allowance Max Storage Price, Max Contract Price, and Max Sector Access
+Price
 
 Playbook:
 
@@ -396,8 +397,9 @@ Notes:
 
 - `--limit` must be used, it's not possible to set allowance on all
   `portals_dev` and `portals_prod` servers at once.
-- Format of `max_storage_price` value must be same as is expected by executing
-  `docker exec sia siac renter setallowance --max-storage-price`
+- Format of `max_storage_price`, `max_contract_price`, `max_sector_access_price`
+  value must be same as is expected by executing
+  `docker exec sia siac renter setallowance --max-storage-price --max-contract-price --max-sector-access-price`
 
 To run:  
 `scripts/portals-set-allowance-price-controls.sh --limit webportals_prod`  

--- a/playbooks/portals-set-allowance-max-storage-price.yml
+++ b/playbooks/portals-set-allowance-max-storage-price.yml
@@ -20,10 +20,10 @@
     - name: Fail if you are targeting all dev and prod webportals
       include_tasks: tasks/host-limit-check.yml
 
-    # Check/install Ansible prerequisities
+    # Check/install Ansible prerequisites
     - name: Include preparing portal prerequisities
       include_tasks: tasks/portals-prepare.yml
 
     # Set allowance
     - name: Set allowance
-      command: "docker exec sia siac renter setallowance --max-storage-price {{ max_storage_price }}"
+      command: "docker exec sia siac renter setallowance --max-storage-price {{ max_storage_price }} --max-contract-price {{ max_contract_price }} --max-sector-access-price {{ max_sector_access_price }}"

--- a/playbooks/portals-set-allowance-price-controls.yml
+++ b/playbooks/portals-set-allowance-price-controls.yml
@@ -29,3 +29,6 @@
       ansible.builtin.command: |
         docker exec sia siac renter setallowance --max-storage-price {{ max_storage_price }} --max-contract-price {{ max_contract_price }} --max-sector-access-price {{ max_sector_access_price }}
       register: set_allowance_result
+      # Verify result to prevent mistakes and misconfiguration, because
+      # setallowance might not fail but just switch to interactive mode.
+      failed_when: set_allowance_result.stdout.find("Allowance updated.") == -1

--- a/playbooks/portals-set-allowance-price-controls.yml
+++ b/playbooks/portals-set-allowance-price-controls.yml
@@ -26,4 +26,11 @@
 
     # Set allowance
     - name: Set allowance
-      command: "docker exec sia siac renter setallowance --max-storage-price {{ max_storage_price }} --max-contract-price {{ max_contract_price }} --max-sector-access-price {{ max_sector_access_price }}"
+      ansible.builtin.command: |
+        docker exec sia siac renter setallowance --max-storage-price {{ max_storage_price }} --max-contract-price {{ max_contract_price }} --max-sector-access-price {{ max_sector_access_price }}
+      register: set_allowance_result
+
+    docker exec sia siac renter setallowance
+      --max-contract-price {{ max_contract_price }}
+      --max-sector-access-price {{ max_sector_access_price }}
+      --max-storage-price {{ max_storage_price }}

--- a/playbooks/portals-set-allowance-price-controls.yml
+++ b/playbooks/portals-set-allowance-price-controls.yml
@@ -12,7 +12,6 @@
   # Playbook specific vars
   vars:
     max_hosts: "{{ groups['webportals'] | length - 1 }}"
-    max_storage_price: "150SC"
 
   tasks:
 
@@ -26,8 +25,11 @@
 
     # Set allowance
     - name: Set allowance
-      ansible.builtin.command: |
-        docker exec sia siac renter setallowance --max-storage-price {{ max_storage_price }} --max-contract-price {{ max_contract_price }} --max-sector-access-price {{ max_sector_access_price }}
+      ansible.builtin.command: >
+        docker exec sia siac renter setallowance 
+          --max-storage-price {{ webportal_allowance.max_storage_price }}
+          --max-contract-price {{ webportal_allowance.max_contract_price }}
+          --max-sector-access-price {{ webportal_allowance.max_sector_access_price }}
       register: set_allowance_result
       # Verify result to prevent mistakes and misconfiguration, because
       # setallowance might not fail but just switch to interactive mode.

--- a/playbooks/portals-set-allowance-price-controls.yml
+++ b/playbooks/portals-set-allowance-price-controls.yml
@@ -29,8 +29,3 @@
       ansible.builtin.command: |
         docker exec sia siac renter setallowance --max-storage-price {{ max_storage_price }} --max-contract-price {{ max_contract_price }} --max-sector-access-price {{ max_sector_access_price }}
       register: set_allowance_result
-
-    docker exec sia siac renter setallowance
-      --max-contract-price {{ max_contract_price }}
-      --max-sector-access-price {{ max_sector_access_price }}
-      --max-storage-price {{ max_storage_price }}

--- a/playbooks/tasks/lastpass-load-webportal-config.yml
+++ b/playbooks/tasks/lastpass-load-webportal-config.yml
@@ -13,7 +13,7 @@
 # Load common/cluster configs defined in a list
 
 # lastpass_portal_common_and_cluster_configs_list defines a list of common/
-# cluster configs to load. Former config valuess can be overriden by later
+# cluster configs to load. Former config values can be overridden by later
 # config values.
 
 - name: Generate list of LastPass paths and variable names

--- a/scripts/portals-set-allowance-price-controls.sh
+++ b/scripts/portals-set-allowance-price-controls.sh
@@ -2,7 +2,7 @@
 
 # Set command and arguments
 cmd=ansible-playbook
-args="--inventory /tmp/ansible-private/inventory/hosts.ini playbooks/portals-set-allowance-max-storage-price.yml $@"
+args="--inventory /tmp/ansible-private/inventory/hosts.ini playbooks/portals-set-allowance-price-controls.yml $@"
 
 # Execute the command
 source $(dirname "$0")/lib/ansible-executor.sh


### PR DESCRIPTION
# PULL REQUEST

## Overview

**Problem:** 
`max-contract-price` and `max-sector-access-price` are only set on server creation and cannot be adjusted via ansible scripts after that.

**Solution:**
Expand `set-allowance-max-storage-price` to also set `max-contract-price` and `max-sector-access-price`.
If this is not the way we want to approach this, we can always close this PR.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
