### PR TITLE
Fix python SDK not installed

### DIFF
--- a/changelog/items/bugs-fixed/fix-python-sdk-fail.md
+++ b/changelog/items/bugs-fixed/fix-python-sdk-fail.md
@@ -1,0 +1,2 @@
+- Fix issue when docker is installed but docker SDK for Python3 is not
+  installed.

--- a/playbooks/portals-setup-following.yml
+++ b/playbooks/portals-setup-following.yml
@@ -40,13 +40,18 @@
       include_tasks: "{{ playbook_dir }}/{{ save_portal_config_handler }}"
 
     - name: Check docker was setup
-      command: docker ps
+      ansible.builtin.command: docker ps
       register: docker_ps_result
+      ignore_errors: True
+
+    - name: Check docker SDK for Python3 was installed
+      ansible.builtin.command: python3 -m pip show docker
+      register: docker_pip_result
       ignore_errors: True
 
     - name: Include stopping portal and other docker containers (if exist)
       include_tasks: tasks/portal-stop-and-docker-containers-stop.yml
-      when: docker_ps_result.failed | default(False) != True
+      when: ((docker_ps_result.failed | default(False)) or (docker_pip_result.failed | default(False))) != True
 
     # Stop docker services gracefully - end
 


### PR DESCRIPTION
# PULL REQUEST

## Overview

Fix portal setup issue when docker is installed, but docker SDK for Python3 is not installed.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
