### PR TITLE
Fix missing become when fixing elasticsearch data directory permissions

### DIFF
--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -46,6 +46,7 @@
         state: directory
         owner: "1000"
         group: "1000"
+      become: True
   when: portal_jaeger_on
 
 # Setup MongoDB


### PR DESCRIPTION
# PULL REQUEST

## Overview

Fix missing `become` for fixing elasticsearch container data permissions.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
