### PR TITLE
Tor blocklist cron

### DIFF
--- a/changelog/items/key-updates/tor-traffic.md
+++ b/changelog/items/key-updates/tor-traffic.md
@@ -1,0 +1,2 @@
+- Add a task to portal setup and a separate playbook to block anonymous Tor
+  traffic.

--- a/my-vars/config-sample-do-not-edit.yml
+++ b/my-vars/config-sample-do-not-edit.yml
@@ -50,7 +50,19 @@
 # advice operators can disable outgoing traffic to local networks. This might
 # disrupt existing services (other than skynet portal stack) on the server.
 # ufw_deny_outgoing_to_local_network: True
-
+#
+# Block Tor traffic (default: True)
+# Anonymous Tor traffic can bring a significant load to the portal and can
+# increase overhead handling abuse of Skynet portal service. By default portal
+# setup blocks Tor traffic. If you once blocked Tor traffic and want to allow/
+# unblock it later, you need to set the following variable to False and undo
+# the setup manually (see config variable block_tor_exit_nodes_lists in
+# webportals.yml and an Ansible task
+# playbooks/tasks/portal-firewall-iptables-block-tor-exit-nodes.yml)
+# - remove root cron job
+# - remove iptables rules
+# - remove ipsets
+# block_tor_exit_nodes: True
 
 ###############################################################################
 # LastPass

--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -49,6 +49,23 @@ local_networks_denied:
   - "198.18.0.0/15"
   - "169.254.0.0/16"
 
+# Iptables: Tor exit nodes blocking
+block_tor_exit_nodes: True
+block_tor_exit_nodes_lists:
+  torproject:
+    url: "https://check.torproject.org/torbulkexitlist?ip="
+    filename: "torproject-exitnodelist"
+    ipset_ipv4: "torproject-exitnodelist-ipv4"
+  dan:
+    url: "https://www.dan.me.uk/torlist/?exit"
+    filename: "dan-exitnodelist"
+    ipset_ipv4: "dan-exitnodelist-ipv4"
+    ipset_ipv6: "dan-exitnodelist-ipv6"
+  # Downloads from dan.me.uk are limited to once per 30 mins (= 1800 secs), we
+  # do not redownload the given number of seconds to prevent errors loading
+  # error message instead of IP list to ipset
+  do_not_redownload_within_secs: 2000
+
 # LastPass settings
 lastpass_ansible_dir: "Shared-Ansible"
 

--- a/playbooks/portals-setup-following.yml
+++ b/playbooks/portals-setup-following.yml
@@ -68,6 +68,13 @@
           become: True
       when: setup_ufw
 
+    - name: Include blocking Tor exit nodes traffic
+      include_tasks: tasks/portal-firewall-iptables-block-tor-exit-nodes.yml
+      args:
+        apply:
+          become: True
+      when: block_tor_exit_nodes
+
     - name: Include server setup
       include_tasks: tasks/portal-setup-server.yml
 

--- a/playbooks/tasks/portal-firewall-iptables-block-tor-exit-nodes.yml
+++ b/playbooks/tasks/portal-firewall-iptables-block-tor-exit-nodes.yml
@@ -1,0 +1,35 @@
+---
+
+# Block Tor exit node traffic
+
+# Requirements:
+# - This task requires to be run as root (become: True)
+
+- name: Update apt packages
+  apt:
+    update_cache: yes
+    cache_valid_time: 900
+
+- name: Ensure requirements are installed
+  apt:
+    name: "{{ item }}"
+    state: latest
+  loop:
+    - iptables
+    - ipset
+    - curl
+
+- name: Create IPv4 ipsets
+  ansible.builtin.command: "ipset -exist create {{ item }} iphash"
+  loop:
+    - "{{ block_tor_exit_nodes_lists.torproject.ipset_ipv4 }}"
+    - "{{ block_tor_exit_nodes_lists.dan.ipset_ipv4 }}"
+
+- name: Create IPv6 ipset
+  ansible.builtin.command: "ipset -exist create {{ block_tor_exit_nodes_lists.dan.ipset_ipv6 }} hash:ip family inet6"
+
+- name: Upload script to update tor exit node lists (used by root cron job)
+  ansible.builtin.template:
+    src: templates/tor-blocklists-update.sh.j2
+    dest: "{{ webportal_dir }}/scripts/tor-blocklists-update.sh"
+    mode: u=rwx,g=r,o=r

--- a/playbooks/tasks/portal-firewall-iptables-block-tor-exit-nodes.yml
+++ b/playbooks/tasks/portal-firewall-iptables-block-tor-exit-nodes.yml
@@ -5,6 +5,12 @@
 # Requirements:
 # - This task requires to be run as root (become: True)
 
+# Output:
+# - ipset for iptables is installed
+# - ipsets are populated initially and updated via periodic cron job with Tor
+#   exit node lists downloaded from internet (Tor Project list and Dan list)
+# - iptables rules are inserted to block IPs from the ipsets
+
 - name: Update apt packages
   apt:
     update_cache: yes
@@ -33,3 +39,44 @@
     src: templates/tor-blocklists-update.sh.j2
     dest: "{{ webportal_dir }}/scripts/tor-blocklists-update.sh"
     mode: u=rwx,g=r,o=r
+
+- name: Check the script execution before adding it as root cron job
+  ansible.builtin.command: "{{ webportal_dir }}/scripts/tor-blocklists-update.sh"
+
+- name: Ensure cron job updating ipsets with Tor exit node lists exists
+  ansible.builtin.cron:
+    name: "Update Tor exit node lists in ipsets"
+    minute: "45"
+    job: "{{ webportal_dir }}/scripts/tor-blocklists-update.sh"
+
+# Primarily we need to block traffic in DOCKER-USER chain, INPUT chain doesn't
+# block incoming traffic from internet to skynet stack in docker containers but
+# it is blocked just to be on sure side.
+
+# Module ansible.builtin.iptables with current Ansible version we use (2.10)
+# doesn't support ipset match_set, so we add rules to iptables by shell module. 
+
+- name: Ensure iptables rules are present
+  # Check if rule exists, if not, insert it
+  ansible.builtin.shell: "{{ item.command }} -C {{ rule }} || {{ item.command }} -I {{ rule }}"
+  vars:
+    rule: "{{ item.chain }} -m set --match-set {{ item.ipset }} src -j DROP"
+  loop:
+    # 2x Tor project IPv4
+    - command: iptables
+      chain: DOCKER-USER
+      ipset: "{{ block_tor_exit_nodes_lists.torproject.ipset_ipv4 }}"
+    - command: iptables
+      chain: INPUT
+      ipset: "{{ block_tor_exit_nodes_lists.torproject.ipset_ipv4 }}"
+    # 2x Dan list IPv4
+    - command: iptables
+      chain: DOCKER-USER
+      ipset: "{{ block_tor_exit_nodes_lists.dan.ipset_ipv4 }}"
+    - command: iptables
+      chain: INPUT
+      ipset: "{{ block_tor_exit_nodes_lists.dan.ipset_ipv4 }}"
+    # Dan list IPv6
+    - command: ip6tables
+      chain: INPUT
+      ipset: "{{ block_tor_exit_nodes_lists.dan.ipset_ipv6 }}"

--- a/playbooks/templates/tor-blocklists-update.sh.j2
+++ b/playbooks/templates/tor-blocklists-update.sh.j2
@@ -61,5 +61,5 @@ if [[ ! -f $timestamp_file || $(cat $timestamp_file) -lt $past ]]; then
     echo "Creating/Updating dan timestamp"
     echo "$(date +%s)" > $timestamp_file
 else
-    echo "It's too soon to redownload dan exitnodelist"
+    echo "It's too soon to redownload dan exitnodelist, using cached version from $(cat $timestamp_file)."
 fi

--- a/playbooks/templates/tor-blocklists-update.sh.j2
+++ b/playbooks/templates/tor-blocklists-update.sh.j2
@@ -27,7 +27,7 @@ if [[ ! -f $timestamp_file || $(cat $timestamp_file) -lt $past ]]; then
     echo "Creating/Updating torproject timestamp"
     echo "$(date +%s)" > $timestamp_file
 else
-    echo "It's too soon to redownload torproject exitnodelist"
+    echo "It's too soon to redownload torproject exitnodelist, using cached version from $(cat $timestamp_file)."
 fi
 
 # Dan list

--- a/playbooks/templates/tor-blocklists-update.sh.j2
+++ b/playbooks/templates/tor-blocklists-update.sh.j2
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Exit on first error
+set -e
+
+# Tor Project
+# Check timestamp (if present)
+# If timestamp doesn't exist or is old enough
+# - Download exit node list 
+# - Load IPs to ipset
+# - Create/Update timestamp
+
+now=$(date +%s)
+past=$((now - {{ block_tor_exit_nodes_lists.do_not_redownload_within_secs }}))
+timestamp_file=/tmp/{{ block_tor_exit_nodes_lists.torproject.filename }}-timestamp
+url={{ block_tor_exit_nodes_lists.torproject.url }}
+file=/tmp/{{ block_tor_exit_nodes_lists.torproject.filename }}
+ipset={{ block_tor_exit_nodes_lists.torproject.ipset_ipv4 }}
+
+if [[ ! -f $timestamp_file || $(cat $timestamp_file) -lt $past ]]; then
+    echo "Downloading torproject exitnodelist"
+    curl -sSL $url -o $file
+
+    echo "Loading torproject exitnodelist to ipset"
+    cat $file | xargs -n 1 ipset -exist add $ipset 
+
+    echo "Creating/Updating torproject timestamp"
+    echo "$(date +%s)" > $timestamp_file
+else
+    echo "It's too soon to redownload torproject exitnodelist"
+fi
+
+# Dan list
+# Check timestamp (if present)
+# If timestamp doesn't exist or is old enough
+# - Download exit node list 
+# - Load IPs to ipset IPv4
+# - Load IPs to ipset IPv6
+# - Create/Update timestamp
+
+now=$(date +%s)
+past=$((now - {{ block_tor_exit_nodes_lists.do_not_redownload_within_secs }}))
+timestamp_file=/tmp/{{ block_tor_exit_nodes_lists.dan.filename }}-timestamp
+url={{ block_tor_exit_nodes_lists.dan.url }}
+file=/tmp/{{ block_tor_exit_nodes_lists.dan.filename }}
+ipset_ipv4={{ block_tor_exit_nodes_lists.dan.ipset_ipv4 }}
+ipset_ipv6={{ block_tor_exit_nodes_lists.dan.ipset_ipv6 }}
+
+if [[ ! -f $timestamp_file || $(cat $timestamp_file) -lt $past ]]; then
+    echo "Downloading dan exitnodelist"
+    curl -sSL $url -o $file
+
+    echo "Loading dan exitnodelist to ipset IPv4"
+    # grep only IPv4
+    cat $file | grep -E "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" | xargs -n 1 ipset -exist add $ipset_ipv4
+
+    echo "Loading dan exitnodelist to ipset IPv6"
+    # grep only IPv6
+    cat $file | grep -E ":" | xargs -n 1 ipset -exist add $ipset_ipv6
+
+    echo "Creating/Updating dan timestamp"
+    echo "$(date +%s)" > $timestamp_file
+else
+    echo "It's too soon to redownload dan exitnodelist"
+fi

--- a/playbooks/templates/tor-blocklists-update.sh.j2
+++ b/playbooks/templates/tor-blocklists-update.sh.j2
@@ -3,7 +3,7 @@
 # Exit on first error
 set -e
 
-# Tor Project
+# Tor Project list
 # Check timestamp (if present)
 # If timestamp doesn't exist or is old enough
 # - Download exit node list 

--- a/playbooks/x-portals-block-tor-exit-nodes.yml
+++ b/playbooks/x-portals-block-tor-exit-nodes.yml
@@ -24,78 +24,9 @@
     - name: Fail if you are targeting all dev and prod webportals
       include_tasks: tasks/host-limit-check.yml
 
-    - name: Update apt packages
-      apt:
-        update_cache: yes
-        cache_valid_time: 900
-      become: True
-    
-    - name: Install ipset
-      apt:
-        name: ipset
-        state: present
-      become: True
-
-    # Tor Project exit nodes list
-
-    - name: Create torproject ipset
-      ansible.builtin.command: ipset -exist create torproject-exitnodelist iphash
-      become: True
-
-    - name: Download torproject exit node list
-      ansible.builtin.command: curl -sSL 'https://check.torproject.org/torbulkexitlist?ip=' -o /tmp/torproject-exitnodelist
-      become: True
-
-    - name: Populate torproject ipset
-      ansible.builtin.shell: cat /tmp/torproject-exitnodelist | xargs -n 1 ipset -exist add torproject-exitnodelist
-      become: True
-    
-    # Incoming requests to skynet stack are handled by DOCKER-USER group, if
-    # they are blocked only in INPUT group they will not be blocked and skynet
-    # is still accessible to them. We block also INPUT group, which is not
-    # needed right now, but just to be sure if some configuration changes
-    # later.
-    - name: Load torproject ipset to iptables
-      ansible.builtin.command: "iptables -I {{ item }} -m set --match-set torproject-exitnodelist src -j DROP"
-      become: True
-      loop:
-        - DOCKER-USER
-        - INPUT
-
-    # Complete Tor exit nodes list
-
-    - name: Create dan IPv4 ipset
-      ansible.builtin.command: ipset -exist create dan-exitnodelist-ipv4 hash:ip
-      become: True
-
-    - name: Create dan IPv6 ipset
-      ansible.builtin.command: ipset -exist create dan-exitnodelist-ipv6 hash:ip family inet6
-      become: True
-
-    # Downloading the list is throttled, we will download once, load twice:
-    # For IPv4 and IPv6
-    - name: Download dan exit node list
-      ansible.builtin.command: curl -sSL 'https://www.dan.me.uk/torlist/?exit' -o /tmp/dan-exitnodelist
-      become: True
-
-    - name: Populate dan IPv4 ipset
-      ansible.builtin.shell: cat /tmp/dan-exitnodelist | grep -E "^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$" | xargs -n 1 ipset -exist add dan-exitnodelist-ipv4
-      become: True
-
-    - name: Populate dan IPv6 ipset
-      ansible.builtin.shell: cat /tmp/dan-exitnodelist | grep -E ":" | xargs -n 1 ipset -exist add dan-exitnodelist-ipv6
-      become: True
-    
-    # See note for DOCKER-USER/INPUT above.
-    - name: Load dan IPv4 ipset to iptables
-      command: "iptables -I {{ item }} -m set --match-set dan-exitnodelist-ipv4 src -j DROP"
-      become: True
-      loop:
-        - DOCKER-USER
-        - INPUT
-    
-    # Currently docker is not installed to support IPv6, ip6tables do not have
-    # DOCKER-USER group, but we block INPUT just to be sure.
-    - name: Load dan IPv6 ipset to ip6tables
-      command: ip6tables -I INPUT -m set --match-set dan-exitnodelist-ipv6 src -j DROP
-      become: True
+    - name: Include blocking Tor exit nodes traffic
+      include_tasks: tasks/portal-firewall-iptables-block-tor-exit-nodes.yml
+      args:
+        apply:
+          become: True
+      when: block_tor_exit_nodes


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR updates a playbook to block Tor exit nodes traffic and updates `portal-setup-following` to use new Tor traffic blocking task. Default option is to block Tor traffic, operators can opt out.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
