### PR TITLE
Ensure scripts directory for Tor block script exists on fresh server

### DIFF
--- a/playbooks/tasks/portal-firewall-iptables-block-tor-exit-nodes.yml
+++ b/playbooks/tasks/portal-firewall-iptables-block-tor-exit-nodes.yml
@@ -34,6 +34,11 @@
 - name: Create IPv6 ipset
   ansible.builtin.command: "ipset -exist create {{ block_tor_exit_nodes_lists.dan.ipset_ipv6 }} hash:ip family inet6"
 
+- name: Make sure scripts directory exists
+  ansible.builtin.file:
+    path: "{{ webportal_dir }}/scripts"
+    state: directory
+
 - name: Upload script to update tor exit node lists (used by root cron job)
   ansible.builtin.template:
     src: templates/tor-blocklists-update.sh.j2


### PR DESCRIPTION
# PULL REQUEST

## Overview

Ensure `skynet-webportal/scripts` directory exists on fresh server for uploading Tor blocking cron script.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
