### PR TITLE
Move cron script to devops folder to avoid path errors

### DIFF
--- a/playbooks/tasks/portal-firewall-iptables-block-tor-exit-nodes.yml
+++ b/playbooks/tasks/portal-firewall-iptables-block-tor-exit-nodes.yml
@@ -1,5 +1,4 @@
 ---
-
 # Block Tor exit node traffic
 
 # Requirements:
@@ -36,30 +35,30 @@
 
 - name: Make sure scripts directory exists
   ansible.builtin.file:
-    path: "{{ webportal_dir }}/scripts"
+    path: "{{ devops_scripts_dir }}"
     state: directory
 
 - name: Upload script to update tor exit node lists (used by root cron job)
   ansible.builtin.template:
     src: templates/tor-blocklists-update.sh.j2
-    dest: "{{ webportal_dir }}/scripts/tor-blocklists-update.sh"
+    dest: "{{ devops_scripts_dir }}/tor-blocklists-update.sh"
     mode: u=rwx,g=r,o=r
 
 - name: Check the script execution before adding it as root cron job
-  ansible.builtin.command: "{{ webportal_dir }}/scripts/tor-blocklists-update.sh"
+  ansible.builtin.command: "{{ devops_scripts_dir }}/tor-blocklists-update.sh"
 
 - name: Ensure cron job updating ipsets with Tor exit node lists exists
   ansible.builtin.cron:
     name: "Update Tor exit node lists in ipsets"
     minute: "45"
-    job: "{{ webportal_dir }}/scripts/tor-blocklists-update.sh"
+    job: "{{ devops_scripts_dir }}/tor-blocklists-update.sh"
 
 # Primarily we need to block traffic in DOCKER-USER chain, INPUT chain doesn't
 # block incoming traffic from internet to skynet stack in docker containers but
 # it is blocked just to be on sure side.
 
 # Module ansible.builtin.iptables with current Ansible version we use (2.10)
-# doesn't support ipset match_set, so we add rules to iptables by shell module. 
+# doesn't support ipset match_set, so we add rules to iptables by shell module.
 
 - name: Ensure iptables rules are present
   # Check if rule exists, if not, insert it


### PR DESCRIPTION
# PULL REQUEST

## Overview
The current `portals-setup-following` script would throw errors due to the updates to the cronjob handling. This addresses those errors by updating the folder that they are downloaded to during setup. 


## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
