### PR TITLE
Enable parallel execution of portal-setup-following

### DIFF
--- a/changelog/items/other/parallel-setups.md
+++ b/changelog/items/other/parallel-setups.md
@@ -1,0 +1,1 @@
+- Add an option to run `portals-setup-following` in parallel.

--- a/playbooks/portals-setup-following.yml
+++ b/playbooks/portals-setup-following.yml
@@ -2,7 +2,7 @@
   hosts: webportals
   remote_user: "{{ webportal_user }}"
   gather_facts: True
-  serial: 1 # Limit concurrency
+  serial: "{{ parallel_setups | default(1) }}" # Limit concurrency
   any_errors_fatal: True # Stop on first error, do not execute on the next host
   vars: # Playbook specific vars
     max_hosts: "{{ groups['webportals'] | length - 1 }}"


### PR DESCRIPTION
# PULL REQUEST

## Overview

Enable to run `portals-setup-following` in parallel using `parallel_setups` variable.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
