### PR TITLE
Switch ignore_errors to failed_when in setup following

### DIFF
--- a/changelog/items/other/failed-when-setup-following.md
+++ b/changelog/items/other/failed-when-setup-following.md
@@ -1,0 +1,2 @@
+- Replace `ignore_errors` with `failed_when` in setup following to avoid
+  confusion around red logs.

--- a/playbooks/portals-setup-following.yml
+++ b/playbooks/portals-setup-following.yml
@@ -39,16 +39,28 @@
     - name: Check docker was setup
       ansible.builtin.command: docker ps
       register: docker_ps_result
-      ignore_errors: True
+      # Use failed_when: False instead of ignore_errors: True so that here isn't
+      # a red logs that are confusing to users.
+      #
+      # NOTE: failed_when: False forces docker_ps_result.failed to be False but
+      # any errors are still recording in docker_ps_result.stderr
+      failed_when: False
 
     - name: Check docker SDK for Python3 was installed
       ansible.builtin.command: python3 -m pip show docker
       register: docker_pip_result
-      ignore_errors: True
+      # Use failed_when: False instead of ignore_errors: True so that here isn't
+      # a red logs that are confusing to users.
+      #
+      # NOTE: failed_when: False forces docker_pip_result.failed to be False but
+      # any errors are still recording in docker_pip_result.stderr
+      failed_when: False
 
+    # If both of the previous tasks were successful and didn't return any
+    # errors, we want to try and stop any active docker containers.
     - name: Include stopping portal and other docker containers (if exist)
       include_tasks: tasks/portal-stop-and-docker-containers-stop.yml
-      when: ((docker_ps_result.failed | default(False)) or (docker_pip_result.failed | default(False))) != True
+      when: docker_ps_result.stderr == '' and docker_pip_result.stderr == ''
 
     # Stop docker services gracefully - end
 

--- a/playbooks/portals-setup-following.yml
+++ b/playbooks/portals-setup-following.yml
@@ -60,7 +60,7 @@
     # errors, we want to try and stop any active docker containers.
     - name: Include stopping portal and other docker containers (if exist)
       include_tasks: tasks/portal-stop-and-docker-containers-stop.yml
-      when: docker_ps_result.stderr == '' and docker_pip_result.stderr == ''
+      when: docker_ps_result.rc == 0 and docker_pip_result.rc == 0
 
     # Stop docker services gracefully - end
 


### PR DESCRIPTION
# PULL REQUEST

## Overview
In `portals-setup-following` we have code to gracefully shut down docker if it is running. This is so that we can rerun the script on portals to update settings. 

We used `ignore_errors: True` on two tasks that could fail if docker isn't set up, i.e. a new portal. This allowed us to check the results in subsequent tasks to determine if we needed to do anything. 

`ignore_errors` still prints out the error in the ansible logs, so users were getting alarmed and confused when they would see the red errors from these tasks when setting up their portals. 

By switching to `failed_when: False` we achieve the same result but with no red error log. This just required updating the following task to look at the errors from these tasks rather than the failed result. 

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
