### PR TITLE
fix personal lastpass handling

### DIFF
--- a/changelog/items/bugs-fixed/lastpass-personal-yml-load-bug.md
+++ b/changelog/items/bugs-fixed/lastpass-personal-yml-load-bug.md
@@ -1,0 +1,1 @@
+- Fix bug in escaping characters for lastpass personal yml note loading

--- a/playbooks/tasks/lastpass-load-json-note.yml
+++ b/playbooks/tasks/lastpass-load-json-note.yml
@@ -24,21 +24,24 @@
 # - Otherwise yaml data from secure note are loaded into output variable.
 
 - name: Check if LastPass item exists
-  local_action:
-    module: ansible.builtin.command
-    # NOTE: We use single quotes around the lastpass paths to ensure the path
-    # separators are not escaped. This is specific handling due to the path
-    # being passed in as a variable to this task. The single quotes wouldn't be
-    # needed if the variable was accessed directly, i.e
-    # lastpass_portal_config_server
-    cmd: "lpass ls --sync now '{{ item.lastpass_path }}'"
+  delegate_to: localhost
+  ansible.builtin.command: "lpass ls --sync now {{ item.lastpass_path }}"
   register: lastpass_ls_result
   changed_when: False
 
 - block:
     - name: Get LastPass data
+      delegate_to: localhost
+      ansible.builtin.command: "lpass show --sync now {{ item.lastpass_path }}"
+      register: lastpass_show_result
+      changed_when: False
+
+    - name: Parse LastPass data
       set_fact:
-        lastpass_data: "{{ lookup('community.general.lastpass', item.lastpass_path, field='notes') | from_json }}"
+        # The stdout_lines contain 2 lines that we don't want, and then the
+        # third line starts with 'Notes: ' and contains the first config field,
+        # so we want to trim that.
+        lastpass_data: "{{ lastpass_show_result.stdout_lines[2:] | join('\n') | replace('Notes: ', '') | from_json }}"
 
     - name: Set variable value from LastPass data
       set_fact:

--- a/playbooks/tasks/lastpass-load-yaml-note.yml
+++ b/playbooks/tasks/lastpass-load-yaml-note.yml
@@ -24,21 +24,24 @@
 # - Otherwise yaml data from secure note are loaded into output variable.
 
 - name: Check if LastPass item exists
-  local_action:
-    module: ansible.builtin.command
-    # NOTE: We use single quotes around the lastpass paths to ensure the path
-    # separators are not escaped. This is specific handling due to the path
-    # being passed in as a variable to this task. The single quotes wouldn't be
-    # needed if the variable was accessed directly, i.e
-    # lastpass_portal_config_server
-    cmd: "lpass ls --sync now '{{ item.lastpass_path }}'"
+  delegate_to: localhost
+  ansible.builtin.command: "lpass ls --sync now {{ item.lastpass_path }}"
   register: lastpass_ls_result
   changed_when: False
 
 - block:
     - name: Get LastPass data
+      delegate_to: localhost
+      ansible.builtin.command: "lpass show --sync now {{ item.lastpass_path }}"
+      register: lastpass_show_result
+      changed_when: False
+
+    - name: Parse LastPass data
       set_fact:
-        lastpass_data: "{{ lookup('community.general.lastpass', item.lastpass_path, field='notes') | from_yaml }}"
+        # The stdout_lines contain 2 lines that we don't want, and then the
+        # third line starts with 'Notes: ' and contains the first config field,
+        # so we want to trim that.
+        lastpass_data: "{{ lastpass_show_result.stdout_lines[2:] | join('\n') | replace('Notes: ', '') | from_yaml }}"
 
     - name: Set variable value from LastPass data
       set_fact:


### PR DESCRIPTION
# PULL REQUEST

## Overview
There was a bug in accessing the LastPass personal yml files.

The `community.general.lastpass` tool was escaping characters differently than the `lpass` cmd. So this PR standardizes the use of `lpass` and updates the parsing of the variable fields. 

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
