### PR TITLE
Fix wallet init with seed flow

### DIFF
--- a/changelog/items/bugs-fixed/wallet-seed-init.md
+++ b/changelog/items/bugs-fixed/wallet-seed-init.md
@@ -1,0 +1,2 @@
+- Fix bug for seed being defined when it wasn't.
+- Add CS sync block for initializing wallet with seed.

--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -123,7 +123,7 @@
 
 - name: Set Sia wallet seed defined
   set_fact:
-    sia_wallet_seed_defined: "{{ webportal_server_config.sia_wallet_seed is defined }}"
+    sia_wallet_seed_defined: "{{ webportal_server_config.sia_wallet_seed is defined and webportal_server_config.sia_wallet_seed != None }}"
 
 # Init a wallet with existing seed
 
@@ -136,6 +136,13 @@
   set_fact:
     setup_status: "{{ setup_status_slurped.content | b64decode }}"
 
+# Init from Seed Block
+#
+# We want to initialize the wallet from a seed if:
+#   - The wallet is not initialized already
+#   - The wallet seed is defined
+#   - The use_existing_sia_seed_if_exists variable is set to True
+#   - The setup_status is not 'initializing'
 - block:
     # Check that the Sia Blockchain is synced
     - name: Check Sia blockchain sync status

--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -137,6 +137,29 @@
     setup_status: "{{ setup_status_slurped.content | b64decode }}"
 
 - block:
+    # Check that the Sia Blockchain is synced
+    - name: Check Sia blockchain sync status
+      command: docker exec sia siac consensus
+      register: siac_consensus_result
+      until: "'Synced: Yes' in siac_consensus_result.stdout"
+      delay: 30
+      retries: 20
+      failed_when: False
+
+    - name: Check if the Sia blockchain is synced
+      fail:
+        msg: |
+          Initializing Sia wallet from Seed requires Sia blockchain to be synced:
+          Sia blockchain is not yet synced:
+
+          {{ siac_consensus_result.stdout }}
+
+          Wait for Sia blockchain synced and rerun the playbook.
+          To check sync status, execute (on the server):
+
+            docker exec sia siac consensus
+      when: "'Synced: Yes' not in siac_consensus_result.stdout"
+
     - name: Initialize a wallet with existing seed
       ansible.builtin.expect:
         command: docker exec -it sia siac wallet init-seed


### PR DESCRIPTION
# PULL REQUEST

## Overview
There were two bugs in the wallet init with seed flow.

First, Sia requires the blockchain to be synced for the wallet to be initialized with the seed. I think this ultimately needs to be first in Sia, but for the time being I added the consensus sync wait so that we at least error because of the right reason. Previously it would error for another unlock check.

Second, I updated the check for if the seed is defined as it was incorrectly thinking it was. 

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
