### PR TITLE
Fix Mongo Init for Single Server

### DIFF
--- a/changelog/items/bugs-fixed/mongo-init.md
+++ b/changelog/items/bugs-fixed/mongo-init.md
@@ -1,0 +1,1 @@
+- Fix mongo cluster initialization for a single server portal.

--- a/playbooks/tasks/portal-mongo-replicaset-check-majority.yml
+++ b/playbooks/tasks/portal-mongo-replicaset-check-majority.yml
@@ -1,5 +1,4 @@
 ---
-
 # Check there is still MongoDB majority if we turn off hosts in the current batch
 
 - name: Check mongo container is running
@@ -37,7 +36,7 @@
 
     - name: Set mongo replicaset initialized
       set_fact:
-        mongo_replicaset_initialized: "{{ not ('NotYetInitialized' in (mongo_shell_result.msg | default(''))) }}"
+        mongo_replicaset_initialized: "{{ not ('NotYetInitialized' in (mongo_shell_result.msg | default(''))) and (mongo_shell_result.failed == False) }}"
 
     # If the MongoDB replicaset was not yet initialized, we can skip MongoDB
     # replicaset majority check, it doesn't matter that we stop the rest of

--- a/playbooks/tasks/portal-role-task-mongo-check-docker-service.yml
+++ b/playbooks/tasks/portal-role-task-mongo-check-docker-service.yml
@@ -1,11 +1,10 @@
 ---
-
 # Check MongoDB docker service runs correctly
 # TODO: This ansible playbook task, should be moved to portal role
 
 # Check mongo container is running correctly
 # Outcome:
-# - mongo_service_ok: boolean flag whether mongo service runs as expected 
+# - mongo_service_ok: boolean flag whether mongo service runs as expected
 
 - name: Include getting wanted docker compose files
   include_tasks: tasks/portal-docker-compose-files-get-wanted.yml
@@ -136,3 +135,14 @@
       {{ mongo_shell_result | to_nice_json }}
   # Log only when checking replicaset status was performed (didn't fail previously)
   when: not (checking_replicaset_result.skipped | default(False)) and not mongo_service_ok
+
+# If the replicaset check was skipped, the mongo_service should not be OK
+- name: Sanity Check on mongo_service_ok
+  fail:
+    msg: |
+      Unexpected condition:
+      mongo_service_ok is {{mongo_service_ok}} and
+      checking_replicaset_result.skipped is {{checking_replicaset_result.skipped}}
+
+      Only one should be True
+  when: (checking_replicaset_result.skipped | default(False)) and mongo_service_ok

--- a/playbooks/tasks/portal-role-task-mongo-replicaset-get-status.yml
+++ b/playbooks/tasks/portal-role-task-mongo-replicaset-get-status.yml
@@ -1,5 +1,4 @@
 ---
-
 # Check if MongoDB replicaset is online and find primary node in the replicaset
 # TODO: This ansible playbook task, should be moved to portal role
 

--- a/playbooks/tasks/portal-role-task-mongo-setup-docker-service.yml
+++ b/playbooks/tasks/portal-role-task-mongo-setup-docker-service.yml
@@ -1,5 +1,4 @@
 ---
-
 # Ensure MongoDB docker service is setup correctly
 # TODO: This ansible playbook task, should be moved to portal role
 
@@ -25,6 +24,8 @@
   when: mgkey_stat_result.stat.isreg | default(False)
   register: mgkey_update_result
 
+# This check confirms that the mongo container is running with the correct
+# permissions. It DOES NOT check if the cluster is initialized.
 - name: Include checking mongo service is running correctly
   include_tasks: tasks/portal-role-task-mongo-check-docker-service.yml
   when: mgkey_stat_result.stat.isreg | default(False) and not mgkey_update_result.changed
@@ -36,6 +37,13 @@
       We will reset the mongo service.
   when: not (mongo_service_ok | default(False))
 
+# Check if the cluster is initialized
+- name: Include getting MongoDB replicaset status
+  include_tasks: tasks/portal-role-task-mongo-replicaset-get-status.yml
+  # If the playbook is run against several hosts, setup replicaset only once
+  # (on the first host of the batch)
+  run_once: True
+
 # Reset mongo service if it is not running correctly
 - block:
     # TODO: This prompt/next fail don't run ok in parallel
@@ -46,9 +54,9 @@
 
           If you do not have any data in your database
           it is safe to continue.
-          Your MongoDB database will be backupped to
+          Your MongoDB database will be backed up to
           {{ mongo_backups_dir }}, deleted and reset.
-          
+
           If you have production data in your database
           you should fix this issue manually and rerun this playbook.
 
@@ -62,7 +70,7 @@
           Your MongoDB database doesn't run as expected,
           you have to fix it manually and then rerun this playbook.
       when: reset_db_result.user_input[:1] not in 'yY'
-    
+
     - name: Stop and remove mongo container
       community.docker.docker_container:
         name: mongo
@@ -168,4 +176,19 @@
       fail:
         msg: "Mongo service doesn't run correctly after reset"
       when: not mongo_service_ok
-  when: not (mongo_service_ok | default(False))
+
+    - name: Include getting MongoDB replicaset status
+      include_tasks: tasks/portal-role-task-mongo-replicaset-get-status.yml
+      # If the playbook is run against several hosts, setup replicaset only once
+      # (on the first host of the batch)
+      run_once: True
+
+    - name: Include setting MongoDB replicaset
+      include_tasks: tasks/portal-role-task-mongo-setup-replicaset-init.yml
+      when: not mongo_replicaset_online
+      # If the playbook is run against several hosts, setup replicaset only once
+      # (on the first host of the batch)
+      run_once: True
+      register: mongo_replicaset_init
+
+  when: not (mongo_service_ok | default(False)) or not mongo_replicaset_online


### PR DESCRIPTION
# PULL REQUEST

## Overview
This PR fixes the mongo initialization for a single server. 

Tested on dev3 as well to ensure it doesn't impact existing mongo cluster. 

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
