### PR TITLE
Add option to include deployment during portal setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,8 +541,7 @@ To run:
 
 ### Setup Portal from Scratch
 
-Setup process requires 3 playbooks (or 2 playbooks if you enable portal deploy
-during portal setup, see playbook `portal-setup-following` below):
+Setup process requires 3 playbooks:
 
 - `portals-setup-initial.sh` (run once)
 - `portals-setup-following.sh`

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ or:
 
 By default portals-deploy playbook performs deployments one server at a time
 (rolling updates/deploys). You can enable parallel deployments (deploy to the
-given number of hosts in parallel) by setting optional `parallel_deploys`
+given number of hosts in parallel) by setting optional `parallel_executions`
 variable in used `config.yml`.
 
 Example `config.yml`:
@@ -232,7 +232,7 @@ portal_repo_version: "deploy-2021-08-24"
 portal_skyd_version: "deploy-2021-08-24"
 portal_accounts_version: "deploy-2021-08-23"
 
-parallel_deploys: 3
+parallel_executions: 3
 ```
 
 #### How to Set Deploy Batch
@@ -541,7 +541,8 @@ To run:
 
 ### Setup Portal from Scratch
 
-Setup process requires 3 playbooks:
+Setup process requires 3 playbooks (or 2 playbooks if you enable portal deploy
+during portal setup, see playbook `portal-setup-following` below):
 
 - `portals-setup-initial.sh` (run once)
 - `portals-setup-following.sh`
@@ -614,6 +615,14 @@ Playbook:
   - Unlock wallet
   - Set default allowance
   - Setup health checks
+- If variable `deploy_after_setup` is set to True
+  - Portal deployment is performed. Then you do not need to run `portals-deploy`
+    playbook separately, it's tasks are performed within `portal-setup-following`
+    playbook.
+- If variable `deploy_after_setup` is not set at all (it is default behaviur) or
+  is set to False
+  - Portal deployment is not performed. You need to run `portals-deploy` playbook
+    separately to bring portal online.
 
 Execute (e.g. on `eu-fin-5`):
 `scripts/portals-setup-following.sh -e @my-vars/config.yml --limit eu-fin-5`

--- a/changelog/items/other/parallel-setups.md
+++ b/changelog/items/other/parallel-setups.md
@@ -1,1 +1,2 @@
+- Rename optional variable `parallel_deploys` to `parallel_executions`.
 - Add an option to run `portals-setup-following` in parallel.

--- a/changelog/items/other/setup-and-deploy.md
+++ b/changelog/items/other/setup-and-deploy.md
@@ -1,0 +1,3 @@
+- Add an option to perform portal deployment in `portals-setup-following`
+  playbook controlled by optional variable `deploy_after_setup`. Default
+  behavior is do not deploy during `portals-setup-following` execution.

--- a/playbooks/portals-deploy.yml
+++ b/playbooks/portals-deploy.yml
@@ -36,7 +36,7 @@
   gather_facts: False
 
   # Limit concurrency
-  serial: "{{ parallel_deploys | default(1) }}"
+  serial: "{{ parallel_executions | default(1) }}"
 
   # Stop on first error, do not execute on the next host
   any_errors_fatal: True
@@ -50,58 +50,5 @@
     portal_action: "portal-deploy"
 
   tasks:
-    # Print timestamp
-    - name: Print timestamp
-      debug:
-        msg: "{{ inventory_hostname + ' deployment start: ' + lookup('pipe','date +%Y-%m-%dT%H:%M:%S') + ' UTC' }}"
-
-    # Check/install Ansible prerequisities
-    - name: Include preparing portal prerequisities
-      include_tasks: tasks/portals-prepare.yml
-
-    # Disable health checks and stop docker services
-    - name: Include disabling health check and stopping portal docker services
-      include_tasks: tasks/portal-stop.yml
-
-    # Rebuild docker images, start the docker services and log activities
-    - name: Include starting portal docker services
-      include_tasks: tasks/portal-docker-services-start.yml
-
-    # Execute Docker command from yml file
-    - name: Executing Docker Command
-      include_tasks: tasks/portal-docker-command.yml
-
-    # Run portal integration tests
-    - name: Include running portal integration tests
-      include_tasks: tasks/portal-integration-tests-run.yml
-
-    # Include running portal health checks
-    - name: Include running portal health checks
-      include_tasks: tasks/portal-health-checks-run.yml
-
-    # Update the allowance if prompted
-    - name: Include Updating the Allowance
-      # Only execute allowance check if portal is manually defined
-      when: update_allowance is defined and inventory_hostname in update_allowance
-      include_tasks: tasks/portal-update-allowance.yml
-
-    # Update log status to 'tested'
-    - name: Update log status to 'tested'
-      include_tasks: tasks/portal-logs-update-status.yml
-      vars:
-        tag_from: "started"
-        tag_to: "tested"
-
-    # Enable health check
-    - name: Include enabling portal health check
-      # do not enable health checks on hosts from out_of_LB group
-      when: ('out_of_LB' not in group_names)
-      include_tasks: tasks/portal-health-check-enable.yml
-
-    # Get portal status
-    - name: Include getting portal status
-      include_tasks: tasks/portal-status-get-status.yml
-
-    # Report portal status to Discord
-    - name: Include reporting status to Discord
-      include_tasks: tasks/portal-status-report-to-discord.yml
+    - name: Including deploying portal
+      include_tasks: tasks/portal-deploy.yml

--- a/playbooks/portals-send-funds.yml
+++ b/playbooks/portals-send-funds.yml
@@ -4,7 +4,7 @@
   gather_facts: False
 
   # Limit concurrency
-  serial: "{{ parallel_deploys | default(1) }}"
+  serial: "{{ parallel_executions | default(1) }}"
 
   # Stop on first error, do not execute on the next host
   any_errors_fatal: True

--- a/playbooks/portals-setup-following.yml
+++ b/playbooks/portals-setup-following.yml
@@ -2,12 +2,21 @@
   hosts: webportals
   remote_user: "{{ webportal_user }}"
   gather_facts: True
-  serial: "{{ parallel_setups | default(1) }}" # Limit concurrency
-  any_errors_fatal: True # Stop on first error, do not execute on the next host
-  vars: # Playbook specific vars
+  # Limit concurrency
+  serial: "{{ parallel_executions | default(1) }}"
+  # Stop on first error, do not execute on the next host
+  any_errors_fatal: True
+  # Playbook specific vars
+  vars:
     max_hosts: "{{ groups['webportals'] | length - 1 }}"
     lastpass_required: True
-    portal_action: "portal-setup"
+    portal_action: "{{ 'portal-setup-and-deploy' if (deploy_after_setup | default(False)) else 'portal-setup' }}"
+
+    # Deploy specific
+    # Rebuild docker services
+    docker_compose_build: True
+    # Set portal, skyd, accounts versions
+    set_portal_versions: True
 
   tasks:
     - name: Check '--limit' is used
@@ -182,6 +191,11 @@
 
     - name: xxx include role task
       include_tasks: tasks/portal-role-task.yml
+
+    # Deploy portal
+    - name: Including deploying portal
+      include_tasks: tasks/portal-deploy.yml
+      when: deploy_after_setup | default(False)
 
   handlers:
     - import_tasks: handlers/main.yml

--- a/playbooks/portals-update-allowance.yml
+++ b/playbooks/portals-update-allowance.yml
@@ -4,7 +4,7 @@
   gather_facts: False
 
   # Limit concurrency
-  serial: "{{ parallel_deploys | default(1) }}"
+  serial: "{{ parallel_executions | default(1) }}"
 
   # Stop on first error, do not execute on the next host
   any_errors_fatal: True

--- a/playbooks/tasks/portal-deploy.yml
+++ b/playbooks/tasks/portal-deploy.yml
@@ -1,0 +1,46 @@
+---
+# Deploy Portal to Server
+
+- name: Print timestamp
+  debug:
+    msg: "{{ inventory_hostname + ' deployment start: ' + lookup('pipe','date +%Y-%m-%dT%H:%M:%S') + ' UTC' }}"
+
+- name: Include preparing portal prerequisities
+  include_tasks: tasks/portals-prepare.yml
+
+- name: Include disabling health check and stopping portal docker services
+  include_tasks: tasks/portal-stop.yml
+
+- name: Include starting portal docker services
+  include_tasks: tasks/portal-docker-services-start.yml
+
+- name: Executing Docker Command
+  include_tasks: tasks/portal-docker-command.yml
+
+- name: Include running portal integration tests
+  include_tasks: tasks/portal-integration-tests-run.yml
+
+- name: Include running portal health checks
+  include_tasks: tasks/portal-health-checks-run.yml
+
+- name: Include Updating the Allowance
+  include_tasks: tasks/portal-update-allowance.yml
+  # Only execute allowance check if portal is manually defined
+  when: update_allowance is defined and inventory_hostname in update_allowance
+
+- name: Update log status to 'tested'
+  include_tasks: tasks/portal-logs-update-status.yml
+  vars:
+    tag_from: "started"
+    tag_to: "tested"
+
+- name: Include enabling portal health check
+  # Do not enable health checks on hosts from out_of_LB group
+  include_tasks: tasks/portal-health-check-enable.yml
+  when: ('out_of_LB' not in group_names)
+
+- name: Include getting portal status
+  include_tasks: tasks/portal-status-get-status.yml
+
+- name: Include reporting portal status to Discord
+  include_tasks: tasks/portal-status-report-to-discord.yml


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR adds an option to perform portal deployment at the end of `portals-setup-following`.

It is controlled by an optional `deploy_after_setup` variable.

By default (if the above variable is missing) deployment is not performed.

Also note that `parallel_deploys` variable was renamed to `parallel_executions`

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
