### PR TITLE
Add saving of cluster configs to lastpass

### DIFF
--- a/changelog/items/key-updates/add-saving-of-cluster-config.md
+++ b/changelog/items/key-updates/add-saving-of-cluster-config.md
@@ -1,0 +1,1 @@
+- Add saving of cluster config

--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -95,10 +95,12 @@ lastpass_portal_credentials_server: "{{ lastpass_ansible_dir }}{{ lastpass_direc
 lastpass_portal_config_common_subfolder: "portal-common-configs"
 lastpass_portal_config_cluster_subfolder: "portal-cluster-configs"
 
+lastpass_portal_config_cluster_file: "{{ lastpass_ansible_dir }}{{ lastpass_directory_separator }}{{ lastpass_portal_config_cluster_subfolder }}{{ lastpass_file_separator }}cluster-{{ portal_cluster_id }}.yml"
+
 # See my-vars/config-sample-do-not-edit.yml file for documentation.
 lastpass_portal_common_and_cluster_configs_list:
   # - "{{ lastpass_ansible_dir }}/{{ lastpass_portal_config_common_subfolder }}/common.yml"
-  - "{{ lastpass_ansible_dir }}{{ lastpass_directory_separator }}{{ lastpass_portal_config_cluster_subfolder }}{{ lastpass_file_separator }}cluster-{{ portal_cluster_id }}.yml"
+  - "{{ lastpass_portal_config_cluster_file }}"
 
 lastpass_portal_config_server_subfolder: "portal-server-configs"
 lastpass_portal_config_server: "{{ lastpass_ansible_dir }}{{ lastpass_directory_separator }}{{ lastpass_portal_config_server_subfolder }}{{ lastpass_file_separator }}{{ inventory_hostname }}.yml"

--- a/playbooks/portals-setup-following.yml
+++ b/playbooks/portals-setup-following.yml
@@ -29,6 +29,7 @@
       set_fact:
         load_portal_config_handler: "tasks/lastpass-load-webportal-config.yml"
         save_portal_config_handler: "tasks/lastpass-save-webportal-config.yml"
+        save_cluster_config_handler: "tasks/lastpass-save-cluster-config.yml"
 
     - name: Include getting portal configs
       include_tasks: tasks/portal-configs-load.yml

--- a/playbooks/tasks/lastpass-save-cluster-config.yml
+++ b/playbooks/tasks/lastpass-save-cluster-config.yml
@@ -1,0 +1,53 @@
+---
+- name: Check if LastPass cluster record exists
+  local_action:
+    module: ansible.builtin.command
+    cmd: "lpass ls --sync now {{ lastpass_portal_config_cluster_file }}"
+  register: lastpass_ls_result
+
+- name: Set LastPass command add or edit
+  set_fact:
+    lastpass_command: "{{ 'add' if lastpass_ls_result.stdout_lines | length == 0 else 'edit' }}"
+
+# Check if there is a difference between the old common config and the current
+# common config.
+- name: Check for a difference in the cluster config file
+  set_fact:
+    difference: "{{ webportal_common_config | difference(webportal_common_config_old) }}"
+
+- block:
+    # TODO: This prompt/next fail shouldn't be run in parallel, i.e. multiple
+    # portals being setup at the same time
+    #
+    # NOTE: the weird use of the join() statement is for formatting. The newline
+    # character \n isn't recognized in this type of multiline string
+    - name: Ask user if it is ok to save the cluster config file
+      pause:
+        prompt: |-
+          It looks like we need to {{ lastpass_command }} your cluster config file in LastPass.
+
+          Here are the fields that appear to need to be {{ lastpass_command }}ed:
+          {{ difference | join("
+          ") }}
+
+          If this doesn't appear to be correct, check your LastPass account and your
+          config files to make sure the playbook is targeting the right files.
+
+          Do you want to {{ lastpass_command }} your cluster config file in LastPass (y/n)?
+      register: update_lastpass_result
+      delegate_to: localhost
+
+    - name: Stop the playbook if the user doesn't want to update LastPass
+      fail:
+        msg: |
+          Your LastPass credentials where not updated, please check your LastPass account
+          and your config files and then rerun this playbook.
+      when: update_lastpass_result.user_input[:1] not in 'yY'
+
+    - name: Update LastPass cluster config record
+      local_action:
+        module: shell
+        cmd: printf "{{ webportal_common_config | to_nice_yaml(width=2048) }}" | lpass {{ lastpass_command }} --sync now --notes --non-interactive {{ lastpass_portal_config_cluster_file }}
+      no_log: True
+
+  when: (lastpass_command == "edit" and difference | length > 0) or lastpass_command == "add"

--- a/playbooks/tasks/lastpass-save-webportal-config.yml
+++ b/playbooks/tasks/lastpass-save-webportal-config.yml
@@ -16,9 +16,3 @@
     module: shell
     cmd: printf '{{ webportal_server_config | to_nice_yaml(width=2048) }}' | lpass {{ lastpass_command }} --sync now --notes --non-interactive {{ lastpass_portal_config_server }}
   no_log: True
-# TODO: Saving missing cluster variables
-# Common/cluster config
-
-# Common/cluster configs list can contain 1 or more LastPass records, later
-# ones override earlier ones, we save missing/default values to the latest
-# LastPass record in the list (the most specific).

--- a/playbooks/tasks/portal-configs-load.yml
+++ b/playbooks/tasks/portal-configs-load.yml
@@ -26,10 +26,14 @@
 
 # If the common/cluster config hasn't been yet saved to secrets backend, it is
 # loaded as undefined now and we set it to empty dictionary.
+#
+# This is also where we want to save a snapshot of the old version to compare
+# against later.
 - name: Set common/cluster config to empty (if it hasn't yet been saved to secrets backend)
   set_fact:
     webportal_common_config: "{{ webportal_common_config | default({}) }}"
     webportal_common_config_last: "{{ webportal_common_config_last | default({}) }}"
+    webportal_common_config_old: "{{ webportal_common_config_last | default({}) }}"
 
 - name: Set portal common/cluster config missing variables to default values to the last config
   set_fact:

--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -324,3 +324,7 @@
       command: crontab -u {{ webportal_user }} {{ webportal_cron_file }}
 
   when: webportal_setup_health_checks
+
+# If we successfully set up the portal, save the cluster configs.
+- name: Include saving the cluster config
+  include_tasks: "{{ playbook_dir }}/{{ save_cluster_config_handler }}"


### PR DESCRIPTION
# PULL REQUEST

## Overview
The cluster configs were not being saved back to LastPass.  This caused new servers to constantly be having the mongo containers reset since the mongo passwords were being autogenerated but not saved. 

The saving of the cluster configs is being handled separately from the saving of the server configs. This is because we only want to save the cluster configs if there are no errors, otherwise, we might be changing values and disrupting the other servers in the cluster. 

Additionally, we check to ensure that we only save the cluster configs if there were changes to the values. 

I tested this on one of my portals and ensured that on the second run of the script, the mongo container is not reset and no updates were prompted for the cluster configs. 

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
