### PR TITLE
Set iptables rules after docker is installed

### DIFF
--- a/changelog/items/bugs-fixed/iptables-after-docker.md
+++ b/changelog/items/bugs-fixed/iptables-after-docker.md
@@ -1,0 +1,2 @@
+- Move setting iptables rules after docker is installed (`DOCKER-USER` chain is
+  present in iptables).

--- a/playbooks/portals-setup-following.yml
+++ b/playbooks/portals-setup-following.yml
@@ -90,15 +90,15 @@
           become: True
       when: setup_ufw
 
+    - name: Include server setup
+      include_tasks: tasks/portal-setup-server.yml
+
     - name: Include blocking Tor exit nodes traffic
       include_tasks: tasks/portal-firewall-iptables-block-tor-exit-nodes.yml
       args:
         apply:
           become: True
       when: block_tor_exit_nodes
-
-    - name: Include server setup
-      include_tasks: tasks/portal-setup-server.yml
 
     - name: Include getting log filename prefix
       include_tasks: tasks/portal-get-log-filename-prefix.yml


### PR DESCRIPTION
# PULL REQUEST

## Overview

Fix issue when we want to set iptables rules for `DOCKER-USER` chain before docker is installed.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
