### PR TITLE
Add portal_modules variable that can be defined in hosts.ini

### DIFF
--- a/changelog/items/key-updates/portal-modules-hosts-ini.md
+++ b/changelog/items/key-updates/portal-modules-hosts-ini.md
@@ -1,0 +1,1 @@
+- Add portal_modules to hosts.ini and reference in default values.

--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -178,7 +178,7 @@ webportal_allowance:
 # TODO: move to role default vars
 webportal_server_config_defaults:
   domain_name: "{{ ansible_host }}"
-  portal_modules: ""
+  portal_modules: "{{ portal_modules | default('') }}"
   sia_wallet_password: ""
   sia_api_port: 9980
   sia_api_password: "{{ lookup('pipe','openssl rand -base64 32') }}"


### PR DESCRIPTION
# PULL REQUEST

## Overview
More variable consolidation. Now we can define the portal_modules in hosts.ini so that we don't need to be interacting with LastPass.

Updated here: https://github.com/SkynetLabs/ansible-private-sample/blob/main/inventory/hosts.ini#L58

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
