### PR TITLE
do not prune docker data in portal-role-task

### DIFF
--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -111,9 +111,6 @@
   # Don't rebuild when initializing sia with existing seed is in progress
   when: create_env_file_result.changed or sia_container_info_result.container == None or not sia_container_info_result.container.State.Running
 
-- name: Include prunning old docker data
-  include_tasks: tasks/portal-docker-prune-old-data.yml
-
 - name: Check wallet
   command: docker exec sia siac wallet
   register: sia_wallet_result


### PR DESCRIPTION
Running setup-portal-following will execute "prunning old docker data" which means that if we run a deploy on a machine, it will remove all docker data older than 4 hours from that machine and following deploy playbook will not take advantage of any cached builds. This is why we removed pruning the docker data step directly before the build step.