### PR TITLE
Fix getting last config LastPass path

### DIFF
--- a/playbooks/tasks/lastpass-save-cluster-config.yml
+++ b/playbooks/tasks/lastpass-save-cluster-config.yml
@@ -1,7 +1,7 @@
 ---
 - name: Get path
   set_fact:
-    cluster_config_last_path: "{{ (lastpass_portal_common_and_cluster_configs_list | last).lastpass_path }}"
+    cluster_config_last_path: "{{ lastpass_portal_common_and_cluster_configs_list | last }}"
 
 - name: Check if LastPass cluster record exists
   local_action:


### PR DESCRIPTION
# PULL REQUEST

## Overview

Fix a bug in selecting last cluster config LastPass path for saving cluster config.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
