### PR TITLE
Add custom difference dict task

### DIFF
--- a/changelog/items/bugs-fixed/dict-difference.md
+++ b/changelog/items/bugs-fixed/dict-difference.md
@@ -1,0 +1,2 @@
+- Added task for checking if a dictionary had a difference as the built in
+  difference method doesn't properly handle all differences.

--- a/playbooks/tasks/dictionary-diff.yml
+++ b/playbooks/tasks/dictionary-diff.yml
@@ -1,0 +1,59 @@
+# The dictionary-diff task compares an original_dict to a new_dict and returns
+# if there is a different and a debug string containing the difference.
+#
+# This task should be called with the following syntax
+#
+# - name: Check Dictionary Diff
+#   vars:
+#     original_dict: "{{ some_dict }}"
+#     new_dict: "{{ another_dict }}"
+#   include_tasks: tasks/dictionary-diff.yml
+#
+# You can then check the different_dict boolean variable to see if there was a
+# difference. And see the difference in the diff_string variable
+
+- name: Initialize Diff Variables
+  set_fact:
+    diff_list: []
+    diff_string: "Dictionary Difference:"
+    different_dict: False
+
+# Check the difference by looping over the new_dict. If the key:value isn't in
+# the original_dict, or the values are not equal, add the key to the diff_list
+- name: Check for new and changed values in the new Dictionary
+  set_fact:
+    diff_list: "{{ diff_list }} + ['{{ item }}']"
+    different_dict: True
+  loop: "{{ new_dict.keys()|list }}"
+  when: item not in original_dict or new_dict[item] != original_dict[item]
+
+# Check for values that are present in original but not in new
+- name: Check the values that were dropped
+  set_fact:
+    diff_list: "{{ diff_list }} + ['{{ item }}']"
+    different_dict: True
+  loop: "{{ original_dict.keys()|list }}"
+  when: item not in new_dict
+
+# Build the diff_string if there was a difference found
+- block:
+    - name: Add 'Original Values' header to diff string
+      set_fact:
+        diff_string: "{{ diff_string }}\n\nOriginal Values"
+
+    - name: Add original values to diff string
+      set_fact:
+        diff_string: "{{ diff_string }}\n {{ item }}: {{ original_dict[item] }}"
+      loop: "{{ diff_list|list }}"
+      when: item in original_dict
+
+    - name: Add 'New Values' header to diff string
+      set_fact:
+        diff_string: "{{ diff_string }}\n\nNew Values"
+
+    - name: Add new values to diff string
+      set_fact:
+        diff_string: "{{ diff_string }}\n {{ item }}: {{ new_dict[item] }}"
+      loop: "{{ diff_list|list }}"
+      when: item in new_dict
+  when: different_dict

--- a/playbooks/tasks/lastpass-save-cluster-config.yml
+++ b/playbooks/tasks/lastpass-save-cluster-config.yml
@@ -16,8 +16,10 @@
 # Check if there is a difference between the old common config and the current
 # common config.
 - name: Check for a difference in the cluster config file
-  set_fact:
-    difference: "{{ webportal_common_config_last | difference(webportal_common_config_last_old) }}"
+  vars:
+    original_dict: "{{ webportal_common_config_last_old }}"
+    new_dict: "{{ webportal_common_config_last }}"
+  include_tasks: tasks/dictionary-diff.yml
 
 - block:
     # TODO: This prompt/next fail shouldn't be run in parallel, i.e. multiple
@@ -31,8 +33,7 @@
           It looks like we need to {{ lastpass_command }} your cluster config file in LastPass.
 
           Here are the fields that appear to need to be {{ lastpass_command }}ed:
-          {{ difference | join("
-          ") }}
+          {{ diff_string }}
 
           If this doesn't appear to be correct, check your LastPass account and your
           config files to make sure the playbook is targeting the right files.
@@ -54,4 +55,4 @@
         cmd: printf "{{ webportal_common_config_last | to_nice_yaml(width=2048) }}" | lpass {{ lastpass_command }} --sync now --notes --non-interactive {{ cluster_config_last_path }}
       no_log: True
 
-  when: (lastpass_command == "edit" and difference | length > 0) or lastpass_command == "add"
+  when: (lastpass_command == "edit" and different_dict ) or lastpass_command == "add"

--- a/playbooks/tasks/portal-versions-rollback-config-files.yml
+++ b/playbooks/tasks/portal-versions-rollback-config-files.yml
@@ -1,5 +1,4 @@
 ---
-
 # Rollback portal config files
 
 # Get list of docker-compose files we want to rollback
@@ -29,6 +28,10 @@
     mode: preserve
   loop: "{{ webportal_docker_compose_files_to_rolback + webportal_other_config_files }}"
 
+# TODO: need to verify if difference() is potentially buggy here.
+#
+# See comment in solution
+# https://stackoverflow.com/questions/40115323/calculate-set-difference-using-jinja2-in-ansible
 - name: Get list of docker-compose files that are present but were not rolled back
   set_fact:
     webportal_docker_compose_files_to_delete: "{{ (webportal_docker_compose_files_mandatory + webportal_docker_compose_files_optional) | difference(webportal_docker_compose_files_to_rolback) }}"


### PR DESCRIPTION
# PULL REQUEST

## Overview
There is a bug in `difference()` that really makes it so that it frankly just doesn't work, which is wild.

https://stackoverflow.com/questions/40115323/calculate-set-difference-using-jinja2-in-ansible

So I created a manual difference checker for dictionaries. While I was at it I was able to have the difference printed out be the `key: value` instead of just the `key`

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

Prints out like the following
```
MSG:

Dictionary Difference:

Original Values
 portal_modules: absu

New Values
 portal_modules: abs
 field1: test
```

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
