### PR TITLE
Increase sia wallet ready timeout

### DIFF
--- a/changelog/items/other/increase-wallet-ready-timeout.md
+++ b/changelog/items/other/increase-wallet-ready-timeout.md
@@ -1,0 +1,1 @@
+- Increase timeout for Sia wallet ready during deployments or restarts.

--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -119,7 +119,8 @@
   register: sia_wallet_result
   until: "'Wallet status:' in sia_wallet_result.stdout"
   delay: 1
-  retries: 120
+  # Currently sia full setup during deploy or restart can take around 8 minutes
+  retries: 900
 
 - name: Set wallet initialized
   set_fact:


### PR DESCRIPTION
# PULL REQUEST

## Overview

Original timeout for sia wallet to become ready was 120 seconds. This PR increases this timeout to 900 seconds as it takes sometimes around 7 - 8 minutes for complete stack (Mongo, ...) to become active after deploys or restarts.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
