### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Fil and Matt are the default owners of the ansible-playbook repo.
+*       @firyx @MSevey


### PR DESCRIPTION
# PULL REQUEST

## Overview
To help with ensuring our code standards I wanted to test out the CODEOWNERS on this repo. This should make it so that either Fil or I have to approve all ansible-playbook PRs. 

You can customize the CODEOWNERS file pretty well, like having certain file types be one owner and other types another. Or it will default to the global owners.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file