### PR TITLE
remove orphans when stopping

### DIFF
--- a/playbooks/tasks/portal-docker-services-stop.yml
+++ b/playbooks/tasks/portal-docker-services-stop.yml
@@ -9,6 +9,7 @@
     project_src: "{{ webportal_dir }}"
     files: "{{ webportal_docker_compose_files_present }}"
     state: absent
+    remove_orphans: True
     # Increase timeout for mongo primary node to step down
     timeout: 30
   become: True


### PR DESCRIPTION
prevent situations like

> Found orphan containers (abuse) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.