### PR TITLE
Autoselect Abuse docker compose files

### DIFF
--- a/changelog/items/other/autoselect-abuse-docker-compose-file.md
+++ b/changelog/items/other/autoselect-abuse-docker-compose-file.md
@@ -1,0 +1,3 @@
+- Abuse docker compose file was renamed in `skynet-webportal` repository. For
+  backwards compatibility Ansible will now select the present Abuse file
+  automatically.

--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -226,7 +226,10 @@ webportal_docker_compose_files_optional:
   - "docker-compose.blocker.yml"
   - "docker-compose.jaeger.yml"
   - "docker-compose.malware-scanner.yml"
+  # Abuse file was renamed, only one of the following two will be present, for
+  # backwards compatibility playbook will select the present one automatically.
   - "docker-compose.abuse-scanner.yml"
+  - "docker-compose.abuse.yml"
   - "docker-compose.override.yml"
 
 # Dictionary of optional portal modules defining which docker-compose files
@@ -237,7 +240,8 @@ webportal_docker_compose_files_dict:
   j: "docker-compose.jaeger.yml"
   m: "docker-compose.mongodb.yml"
   s: "docker-compose.malware-scanner.yml"
-  u: "docker-compose.abuse-scanner.yml"
+  # See Abuse file comment above
+  u: ["docker-compose.abuse-scanner.yml", "docker-compose.abuse.yml"]
 
 webportal_other_config_files:
   - ".env"

--- a/playbooks/tasks/portal-docker-compose-files-get-wanted.yml
+++ b/playbooks/tasks/portal-docker-compose-files-get-wanted.yml
@@ -94,7 +94,7 @@
     - name: Check there is exactly 1 Abuse docker-compose file
       ansible.builtin.assert:
         that:
-          - abuse_files == 1
+          - "{{ abuse_files }} == 1"
         fail_msg: |
           There must be exactly 1 present Abuse docker-compose file.
           Got {{ abuse_files }} present Abuse files.
@@ -103,7 +103,7 @@
       set_fact:
         webportal_docker_compose_files_wanted: >-
           {{ webportal_docker_compose_files_wanted +
-          [webportal_docker_compose_files_dict['m'], webportal_docker_compose_files_dict['b'], {{ item }}] }}
+          [webportal_docker_compose_files_dict['m'], webportal_docker_compose_files_dict['b'], item] }}
       when: abuse_files_stat_result.results[loop_index].stat.exists
       loop: "{{ webportal_docker_compose_files_dict['u'] }}"
       loop_control:

--- a/playbooks/tasks/portal-docker-compose-files-get-wanted.yml
+++ b/playbooks/tasks/portal-docker-compose-files-get-wanted.yml
@@ -34,45 +34,80 @@
 # Add optional docker-compose files defined by PORTAL_MODULES
 # See https://github.com/SkynetLabs/skynet-webportal/blob/master/dc
 
-- name: Add accounts docker-compose files
+- name: Add accounts docker-compose file
   set_fact:
     webportal_docker_compose_files_wanted: >-
       {{ webportal_docker_compose_files_wanted +
       [webportal_docker_compose_files_dict['m'], webportal_docker_compose_files_dict['a']] }}
   when: "'a' in portal_modules"
 
-- name: Add blocker docker-compose files
+- name: Add blocker docker-compose file
   set_fact:
     webportal_docker_compose_files_wanted: >-
       {{ webportal_docker_compose_files_wanted +
       [webportal_docker_compose_files_dict['m'], webportal_docker_compose_files_dict['b']] }}
   when: "'b' in portal_modules"
 
-- name: Add jaeger docker-compose files
+- name: Add jaeger docker-compose file
   set_fact:
     webportal_docker_compose_files_wanted: >-
       {{ webportal_docker_compose_files_wanted +
       [webportal_docker_compose_files_dict['j']] }}
   when: "'j' in portal_modules"
 
-- name: Add malware-scanner docker-compose files
+- name: Add malware-scanner docker-compose file
   set_fact:
     webportal_docker_compose_files_wanted: >-
       {{ webportal_docker_compose_files_wanted +
       [webportal_docker_compose_files_dict['b'], webportal_docker_compose_files_dict['m'], webportal_docker_compose_files_dict['s']] }}
   when: "'s' in portal_modules"
 
-- name: Add mongo docker-compose files
+- name: Add mongo docker-compose file
   set_fact:
     webportal_docker_compose_files_wanted: >-
       {{ webportal_docker_compose_files_wanted +
       [webportal_docker_compose_files_dict['m']] }}
 
-- name: Add abuse-scanner docker-compose files
-  set_fact:
-    webportal_docker_compose_files_wanted: >-
-      {{ webportal_docker_compose_files_wanted +
-      [webportal_docker_compose_files_dict['m'], webportal_docker_compose_files_dict['b'], webportal_docker_compose_files_dict['u']] }}
+- name: Add Abuse docker-compose file
+  block:
+    # Abuse docker-compose file was renamed in skynet-webportal repository, for
+    # backwards compatibility the playbook will automatically select the file
+    # that is present.
+
+    - name: Check which Abuse docker-compose file is present
+      ansible.builtin.stat:
+        path: "{{ webportal_dir }}/{{ item }}"
+        get_attributes: False
+        get_checksum: False
+        get_mime: False
+      register: abuse_files_stat_result
+      loop: "{{ webportal_docker_compose_files_dict['u'] }}"
+
+    - name: Reset Abuse docker-compose files count
+      set_fact:
+        abuse_files: 0
+
+    - name: Count Abuse docker-compose files
+      set_fact:
+        abuse_files: "{{ abuse_files + 1 }}"
+
+    - name: Check there is exactly 1 Abuse docker-compose file
+      ansible.builtin.assert:
+        that:
+          - abuse_files == 1
+        fail_msg: |
+          There must be exactly 1 present Abuse docker-compose file.
+          Got {{ abuse_files }} present Abuse files.
+
+    - name: Add present Abuse docker-compose file
+      set_fact:
+        webportal_docker_compose_files_wanted: >-
+          {{ webportal_docker_compose_files_wanted +
+          [webportal_docker_compose_files_dict['m'], webportal_docker_compose_files_dict['b'], {{ item }}] }}
+      when: abuse_files_stat_result.results[loop_index].stat.exists
+      loop: "{{ webportal_docker_compose_files_dict['u'] }}"
+      loop_control:
+        index_var: loop_index
   when: "'u' in portal_modules"
 
 - name: Add docker-compose.override.yml file to the list

--- a/playbooks/tasks/portal-docker-compose-files-get-wanted.yml
+++ b/playbooks/tasks/portal-docker-compose-files-get-wanted.yml
@@ -34,14 +34,14 @@
 # Add optional docker-compose files defined by PORTAL_MODULES
 # See https://github.com/SkynetLabs/skynet-webportal/blob/master/dc
 
-- name: Add accounts docker-compose file
+- name: Add accounts docker-compose files
   set_fact:
     webportal_docker_compose_files_wanted: >-
       {{ webportal_docker_compose_files_wanted +
       [webportal_docker_compose_files_dict['m'], webportal_docker_compose_files_dict['a']] }}
   when: "'a' in portal_modules"
 
-- name: Add blocker docker-compose file
+- name: Add blocker docker-compose files
   set_fact:
     webportal_docker_compose_files_wanted: >-
       {{ webportal_docker_compose_files_wanted +
@@ -55,7 +55,7 @@
       [webportal_docker_compose_files_dict['j']] }}
   when: "'j' in portal_modules"
 
-- name: Add malware-scanner docker-compose file
+- name: Add malware-scanner docker-compose files
   set_fact:
     webportal_docker_compose_files_wanted: >-
       {{ webportal_docker_compose_files_wanted +
@@ -90,6 +90,10 @@
     - name: Count Abuse docker-compose files
       set_fact:
         abuse_files: "{{ abuse_files + 1 }}"
+      when: abuse_files_stat_result.results[loop_index].stat.exists
+      loop: "{{ webportal_docker_compose_files_dict['u'] }}"
+      loop_control:
+        index_var: loop_index
 
     - name: Check there is exactly 1 Abuse docker-compose file
       ansible.builtin.assert:


### PR DESCRIPTION
# PULL REQUEST

## Overview

Abuse docker compose file was renamed in `skynet-webportal` repo, for backwards compatibility playbooks need to support both versions. This PR enables playbooks to automatically select present Abuse docker compose file.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
