### PR TITLE
Do not wait for uploads/downloads when sia is restarting

### DIFF
--- a/changelog/items/other/no-wait-for-restarting-sia.md
+++ b/changelog/items/other/no-wait-for-restarting-sia.md
@@ -1,0 +1,1 @@
+- Do not wait for uploads/downloads to finish when sia container is restarting.

--- a/playbooks/tasks/portal-health-check-disable.yml
+++ b/playbooks/tasks/portal-health-check-disable.yml
@@ -84,8 +84,9 @@
         - docker_renter_downloads.stderr != ''
         - docker_renter_downloads.stderr.find("490 Module not loaded") == -1
 
-  # Do not wait if sia container is not running
+  # Do not wait if sia container is not running or is restarting
   when:
     - sia_docker_container_result.exists
     - sia_docker_container_result.container is defined
     - sia_docker_container_result.container.State.Running
+    - not sia_docker_container_result.container.State.Restarting


### PR DESCRIPTION
# PULL REQUEST

## Overview

When disabling health checks (e.g. when executing takedown playbook) we wait for uploads and downloads to finish. This expects `sia` container to be running. This PR skips waiting (fixes an issue) when sia container is restarting.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
