### PR TITLE
Fix devops permissions

### DIFF
--- a/changelog/items/bugs-fixed/fix-devops-dir-permissions.md
+++ b/changelog/items/bugs-fixed/fix-devops-dir-permissions.md
@@ -1,0 +1,1 @@
+- Fix permissions of `devops` directory on fresh setup.

--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -132,8 +132,8 @@ mongo_mgkey_file: "{{ mongo_data_dir }}/mgkey"
 
 # Devops Paths
 devops_dir: "{{ webportal_user_home_dir }}/devops"
-block_tor_exit_nodes_script_file: "{{ devops_scripts_dir }}/tor-blocklists-update.sh"
 devops_scripts_dir: "{{ devops_dir }}/scripts"
+block_tor_exit_nodes_script_file: "{{ devops_scripts_dir }}/tor-blocklists-update.sh"
 logs_dir: "{{ devops_dir }}/logs"
 setup_status_dir: "{{ devops_dir }}/setup"
 setup_status_file: "{{ setup_status_dir }}/status"

--- a/playbooks/tasks/portal-firewall-iptables-block-tor-exit-nodes.yml
+++ b/playbooks/tasks/portal-firewall-iptables-block-tor-exit-nodes.yml
@@ -33,17 +33,12 @@
 - name: Create IPv6 ipset
   ansible.builtin.command: "ipset -exist create {{ block_tor_exit_nodes_lists.dan.ipset_ipv6 }} hash:ip family inet6"
 
-- name: Make sure devops directory with user permissions exists
-  ansible.builtin.file:
-    path: "{{ devops_dir }}"
-    state: directory
-    owner: user
-    group: user
-
-- name: Make sure scripts directory exists
+- name: Make sure devops/scripts directory exists
   ansible.builtin.file:
     path: "{{ devops_scripts_dir }}"
     state: directory
+    owner: user
+    group: user
 
 - name: Upload script to update tor exit node lists (used by root cron job)
   ansible.builtin.template:

--- a/playbooks/tasks/portal-firewall-iptables-block-tor-exit-nodes.yml
+++ b/playbooks/tasks/portal-firewall-iptables-block-tor-exit-nodes.yml
@@ -33,6 +33,13 @@
 - name: Create IPv6 ipset
   ansible.builtin.command: "ipset -exist create {{ block_tor_exit_nodes_lists.dan.ipset_ipv6 }} hash:ip family inet6"
 
+- name: Make sure devops directory with user permissions exists
+  ansible.builtin.file:
+    path: "{{ devops_dir }}"
+    state: directory
+    owner: user
+    group: user
+
 - name: Make sure scripts directory exists
   ansible.builtin.file:
     path: "{{ devops_scripts_dir }}"


### PR DESCRIPTION
# PULL REQUEST

## Overview

On fresh server, `devops/scripts` dir was created with root permissions, causing issues later. This PR fixes the permissions.

Already tested on a fresh portal.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
