### PR TITLE
Add ability to override docker images

### DIFF
--- a/changelog/items/key-updates/docker-image-overrides.yml
+++ b/changelog/items/key-updates/docker-image-overrides.yml
@@ -1,0 +1,1 @@
+- Add the ability to override docker images

--- a/my-vars/config-sample-do-not-edit.yml
+++ b/my-vars/config-sample-do-not-edit.yml
@@ -185,6 +185,15 @@ git_checkout_email: ""
 # website_custom_build_context:
 # website_custom_build_dockerfile:
 
+# Custom docker images.
+#
+# If you want to override a docker image for a specific service, you can do so
+# by defining the service and image in the docker_image_overrides variable.
+#
+# docker_image_overrides:
+#   - { service: "website", image: "skynetlabs/website-skynetpro-net" }
+#   - { service: "blocker", image: "skynetlabs/blocker" }
+
 # Set the skynet-webportal, skyd, and accounts versions by entering a git
 # branch, git tag or git commit.
 portal_repo_version: "..."

--- a/playbooks/group_vars/webportals_pro.yml
+++ b/playbooks/group_vars/webportals_pro.yml
@@ -1,0 +1,4 @@
+# Config override for pro servers (hosts in webportals_pro group)
+
+docker_image_overrides:
+  - { service: "website", image: "{{ website_docker_image }}" }

--- a/playbooks/group_vars/webportals_pro.yml
+++ b/playbooks/group_vars/webportals_pro.yml
@@ -1,4 +1,5 @@
 # Config override for pro servers (hosts in webportals_pro group)
 
 docker_image_overrides:
+  # yamllint disable-line rule:braces
   - { service: "website", image: "{{ website_docker_image }}" }

--- a/playbooks/tasks/portal-versions-set.yml
+++ b/playbooks/tasks/portal-versions-set.yml
@@ -73,6 +73,21 @@
     - website_custom_build_context is defined
     - website_custom_build_dockerfile is defined
 
+# Handle setting an docker image overrides
+#
+# Expected syntax
+# docker_image_overrides:
+#   - { service: "website", image: "skynetlabs/website-skynetpro-net" }
+#   - { service: "blocker", image: "skynetlabs/blocker" }
+
+- name: Set docker image overrides
+  set_fact:
+    # ignoring ansible-lint var-spacing here because it is a false failure
+    # caused by the }}}}} in the combine statement
+    docker_compose_override_data: "{{ docker_compose_override_data | combine({'services': {item.service: {'image': item.image}}}, recursive=True) }}" # noqa var-spacing
+  loop: "{{ docker_image_overrides }}"
+  when: docker_image_overrides is defined
+
 # Handle accounts. Account version can be set via accounts docker image in
 # docker-compose.accounts.yml otherwise via branch in config.yml variable.
 


### PR DESCRIPTION
# PULL REQUEST

## Overview
This PR adds the ability to override multiple docker images when defined in the following format:
```yml
docker_image_overrides:
  - { service: "website", image: "skynetlabs/website-skynetpro-net" }
  - { service: "blocker", image: "skynetlabs/blocker" }
```

Additionally, the default image override for the websites was added for the pro cluster. This pulls from the hosts.ini file in the ansible private repo where I added children to the pro cluster for skynetpro and skynetfree, to define their specific image variables.

https://github.com/SkynetLabs/ansible-private/blob/master/inventory/hosts.ini#L122

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
