### PR TITLE
Update vars_files definitions

### DIFF
--- a/playbooks/portals-block-unblock-incoming-traffic.yml
+++ b/playbooks/portals-block-unblock-incoming-traffic.yml
@@ -13,8 +13,10 @@
     max_hosts: "{{ groups['webportals'] | length - 1 }}"
     lastpass_required: True
   vars_files:
-    - "{{ common_vars_file }}"
-    - "{{ custom_vars_file  }}"
+    # Define as an array to handle undefined files. At least one file needs to
+    # be defined otherwise there will be an error. common_vars_file is expected
+    # to always be defined.
+    - ["{{ common_vars_file }}", "{{ custom_vars_file  }}"]
 
   tasks:
     - name: Fail if you are targeting all dev and prod webportals

--- a/playbooks/portals-deploy.yml
+++ b/playbooks/portals-deploy.yml
@@ -19,8 +19,10 @@
     batch_number: 1
 
   vars_files:
-    - "{{ common_vars_file }}"
-    - "{{ custom_vars_file  }}"
+    # Define as an array to handle undefined files. At least one file needs to
+    # be defined otherwise there will be an error. common_vars_file is expected
+    # to always be defined.
+    - ["{{ common_vars_file }}", "{{ custom_vars_file  }}"]
 
   tasks:
     # Check '--limit' is used

--- a/playbooks/portals-set-vm-max-map-count.yml
+++ b/playbooks/portals-set-vm-max-map-count.yml
@@ -15,8 +15,10 @@
     lastpass_required: True
     vm_max_map_count: 262144
   vars_files:
-    - "{{ common_vars_file }}"
-    - "{{ custom_vars_file  }}"
+    # Define as an array to handle undefined files. At least one file needs to
+    # be defined otherwise there will be an error. common_vars_file is expected
+    # to always be defined.
+    - ["{{ common_vars_file }}", "{{ custom_vars_file  }}"]
 
   tasks:
     # Set vm.max_map_count directly

--- a/playbooks/portals-setup-following.yml
+++ b/playbooks/portals-setup-following.yml
@@ -18,8 +18,10 @@
     # Set portal, skyd, accounts versions
     set_portal_versions: True
   vars_files:
-    - "{{ common_vars_file }}"
-    - "{{ custom_vars_file  }}"
+    # Define as an array to handle undefined files. At least one file needs to
+    # be defined otherwise there will be an error. common_vars_file is expected
+    # to always be defined.
+    - ["{{ common_vars_file }}", "{{ custom_vars_file  }}"]
 
   tasks:
     - name: Check '--limit' is used

--- a/playbooks/portals-setup-initial.yml
+++ b/playbooks/portals-setup-initial.yml
@@ -27,8 +27,10 @@
     lastpass_required: True
     lastpass_allow_missing_user_credentials: True
   vars_files:
-    - "{{ common_vars_file }}"
-    - "{{ custom_vars_file  }}"
+    # Define as an array to handle undefined files. At least one file needs to
+    # be defined otherwise there will be an error. common_vars_file is expected
+    # to always be defined.
+    - ["{{ common_vars_file }}", "{{ custom_vars_file  }}"]
   tasks:
     - name: Fail if you are targeting all dev and prod webportals
       include_tasks: tasks/host-limit-check.yml
@@ -46,8 +48,10 @@
   vars:
     lastpass_required: True
   vars_files:
-    - "{{ common_vars_file }}"
-    - "{{ custom_vars_file  }}"
+    # Define as an array to handle undefined files. At least one file needs to
+    # be defined otherwise there will be an error. common_vars_file is expected
+    # to always be defined.
+    - ["{{ common_vars_file }}", "{{ custom_vars_file  }}"]
   tasks:
     - name: Skip if initial root like user is defined
       meta: end_host
@@ -81,8 +85,10 @@
     # LastPass required to set webportal_temp_user password to webportal_user password
     lastpass_required: True
   vars_files:
-    - "{{ common_vars_file }}"
-    - "{{ custom_vars_file  }}"
+    # Define as an array to handle undefined files. At least one file needs to
+    # be defined otherwise there will be an error. common_vars_file is expected
+    # to always be defined.
+    - ["{{ common_vars_file }}", "{{ custom_vars_file  }}"]
   tasks:
     - name: Skip if initial root like user is not defined
       meta: end_host
@@ -167,8 +173,10 @@
     # webportal_user password from LastPass
     lastpass_required: True
   vars_files:
-    - "{{ common_vars_file }}"
-    - "{{ custom_vars_file  }}"
+    # Define as an array to handle undefined files. At least one file needs to
+    # be defined otherwise there will be an error. common_vars_file is expected
+    # to always be defined.
+    - ["{{ common_vars_file }}", "{{ custom_vars_file  }}"]
   tasks:
     - name: Skip if initial root like user is not defined
       meta: end_host

--- a/playbooks/portals-setup-ufw.yml
+++ b/playbooks/portals-setup-ufw.yml
@@ -14,8 +14,10 @@
     max_hosts: "{{ groups['webportals'] | length - 1 }}"
     lastpass_required: True
   vars_files:
-    - "{{ common_vars_file }}"
-    - "{{ custom_vars_file  }}"
+    # Define as an array to handle undefined files. At least one file needs to
+    # be defined otherwise there will be an error. common_vars_file is expected
+    # to always be defined.
+    - ["{{ common_vars_file }}", "{{ custom_vars_file  }}"]
 
   tasks:
     # Check '--limit' is used

--- a/playbooks/x-portals-block-tor-exit-nodes.yml
+++ b/playbooks/x-portals-block-tor-exit-nodes.yml
@@ -20,8 +20,10 @@
     max_hosts: "{{ groups['webportals'] | length - 1 }}"
     lastpass_required: True
   vars_files:
-    - "{{ common_vars_file }}"
-    - "{{ custom_vars_file  }}"
+    # Define as an array to handle undefined files. At least one file needs to
+    # be defined otherwise there will be an error. common_vars_file is expected
+    # to always be defined.
+    - ["{{ common_vars_file }}", "{{ custom_vars_file  }}"]
 
   tasks:
     - name: Fail if you are targeting all dev and prod webportals

--- a/playbooks/x-portals-ensure-latest-docker.yml
+++ b/playbooks/x-portals-ensure-latest-docker.yml
@@ -17,8 +17,10 @@
     portal_action: "portal-ensure-latest-docker"
     lastpass_required: True
   vars_files:
-    - "{{ common_vars_file }}"
-    - "{{ custom_vars_file  }}"
+    # Define as an array to handle undefined files. At least one file needs to
+    # be defined otherwise there will be an error. common_vars_file is expected
+    # to always be defined.
+    - ["{{ common_vars_file }}", "{{ custom_vars_file  }}"]
 
   tasks:
     - name: Fail if you are targeting all dev and prod webportals

--- a/playbooks/x-portals-setup-dev-tools.yml
+++ b/playbooks/x-portals-setup-dev-tools.yml
@@ -14,8 +14,10 @@
     max_hosts: "{{ groups['webportals'] | length - 1 }}"
     lastpass_required: True
   vars_files:
-    - "{{ common_vars_file }}"
-    - "{{ custom_vars_file  }}"
+    # Define as an array to handle undefined files. At least one file needs to
+    # be defined otherwise there will be an error. common_vars_file is expected
+    # to always be defined.
+    - ["{{ common_vars_file }}", "{{ custom_vars_file  }}"]
 
   tasks:
     # Check '--limit' is used

--- a/playbooks/x-portals-setup-disable-swap.yml
+++ b/playbooks/x-portals-setup-disable-swap.yml
@@ -14,8 +14,10 @@
     max_hosts: "{{ groups['webportals'] | length - 1 }}"
     lastpass_required: True
   vars_files:
-    - "{{ common_vars_file }}"
-    - "{{ custom_vars_file  }}"
+    # Define as an array to handle undefined files. At least one file needs to
+    # be defined otherwise there will be an error. common_vars_file is expected
+    # to always be defined.
+    - ["{{ common_vars_file }}", "{{ custom_vars_file  }}"]
 
   tasks:
     # Check '--limit' is used

--- a/playbooks/x-portals-setup-serverlist.yml
+++ b/playbooks/x-portals-setup-serverlist.yml
@@ -18,8 +18,10 @@
     serverlist_version: "v0.0.4"
     serverlist_command: "{{ devops_scripts_dir }}/servers {{ webportal_dir }}/.env"
   vars_files:
-    - "{{ common_vars_file }}"
-    - "{{ custom_vars_file  }}"
+    # Define as an array to handle undefined files. At least one file needs to
+    # be defined otherwise there will be an error. common_vars_file is expected
+    # to always be defined.
+    - ["{{ common_vars_file }}", "{{ custom_vars_file  }}"]
 
   tasks:
     # Check '--limit' is used


### PR DESCRIPTION
# PULL REQUEST

## Overview
Turns out ansible handles undefined vars files differently based on if `gather_facts` is true or false.

When it is false, it doesn't care if the vars_files are defined

When it is true, it will error.

Defining the `vars_files` as an array allows ansible to load any that are defined, as long as one is defined. I added the `common_vars_file` to the ansible-private-sample repo to make it a required variable so it is always defined.

https://github.com/SkynetLabs/ansible-private-sample/pull/3

This makes sense as we can then work on moving all custom variables to these custom var files and out of hosts.ini and the `my-vars` directory in this repo. 

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
