### PR TITLE
Sky 315 handle torproject exitnode outage

### DIFF
--- a/changelog/items/other/handle-torproject-exitnodelist-outage.md
+++ b/changelog/items/other/handle-torproject-exitnodelist-outage.md
@@ -1,0 +1,1 @@
+- Handle Tor Project exit node list service outage.

--- a/playbooks/templates/tor-blocklists-update.sh.j2
+++ b/playbooks/templates/tor-blocklists-update.sh.j2
@@ -22,13 +22,21 @@ if [[ ! -f $timestamp_file || $(cat $timestamp_file) -lt $past ]]; then
     curl -sSL $url -o $file
 
     echo "Loading torproject exitnodelist to ipset"
-    cat $file | xargs -n 1 ipset -exist add $ipset 
+
+    if [ -s $file ]; then
+        # The file is not-empty.
+        cat $file | xargs -r -n 1 ipset -exist add $ipset
+    else
+        # The file is empty.
+        echo 'Official torproject exitnodelist seems to have outage, we skip and continue the the next, unofficial list.'
+    fi
 
     echo "Creating/Updating torproject timestamp"
     echo "$(date +%s)" > $timestamp_file
 else
     echo "It's too soon to redownload torproject exitnodelist, using cached version from $(cat $timestamp_file)."
 fi
+
 
 # Dan list
 # Check timestamp (if present)

--- a/playbooks/templates/tor-blocklists-update.sh.j2
+++ b/playbooks/templates/tor-blocklists-update.sh.j2
@@ -28,7 +28,7 @@ if [[ ! -f $timestamp_file || $(cat $timestamp_file) -lt $past ]]; then
         cat $file | xargs -n 1 ipset -exist add $ipset
     else
         # The file is empty.
-        echo 'Official torproject exitnodelist seems to have outage, we skip and continue the the next, unofficial list.'
+        echo 'Official torproject exitnodelist seems to have outage, we skip and continue with the next, unofficial list.'
     fi
 
     echo "Creating/Updating torproject timestamp"

--- a/playbooks/templates/tor-blocklists-update.sh.j2
+++ b/playbooks/templates/tor-blocklists-update.sh.j2
@@ -25,7 +25,7 @@ if [[ ! -f $timestamp_file || $(cat $timestamp_file) -lt $past ]]; then
 
     if [ -s $file ]; then
         # The file is not-empty.
-        cat $file | xargs -r -n 1 ipset -exist add $ipset
+        cat $file | xargs -n 1 ipset -exist add $ipset
     else
         # The file is empty.
         echo 'Official torproject exitnodelist seems to have outage, we skip and continue the the next, unofficial list.'


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR fixes 2 issues when official Tor Project Exit Node List service has outage:
- we can't deploy, because deploy script fails checking Tor blocking script before adding it to cron
- cron job fails and doesn't downloads/updates the second, unofficial Tor blocklist

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
