### PR TITLE
Create logs dir to fix S3 backup

### DIFF
--- a/changelog/items/bugs-fixed/fix-missing-logs-dir.md
+++ b/changelog/items/bugs-fixed/fix-missing-logs-dir.md
@@ -1,0 +1,1 @@
+- Create webportal `logs` dir to fix some of the cron jobs (e.g. backup to S3).

--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -119,6 +119,7 @@ lastpass_accounts_jwks_json: "{{ lastpass_ansible_dir }}{{ lastpass_directory_se
 # Webportal Paths
 webportal_user_home_dir: "/home/{{ webportal_user }}"
 webportal_dir: "{{ webportal_user_home_dir }}/skynet-webportal"
+webportal_logs_dir: "{{ webportal_dir }}/logs"
 webportal_cron_file: "{{ webportal_dir }}/setup-scripts/support/crontab"
 elasticsearch_data_data_dir: "{{ webportal_dir }}/docker/data/elasticsearch/data"
 
@@ -212,7 +213,7 @@ webportal_common_config_defaults:
 
 # TODO: move to role default vars
 # TODO: default to: False
-webportal_setup_health_checks: True
+webportal_setup_cron_jobs: True
 
 # =============================================================================
 # Portal deploy settings (on running server)

--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -316,7 +316,7 @@
   failed_when: set_allowance_result.stdout.find("Allowance updated. 10 setting(s) changed.") == -1
   when: allowance_is_not_set
 
-# Setup health checks
+# Setup cron jobs
 # TODO: Move to role task file
 - block:
     - name: Install Python modules for health checks
@@ -327,6 +327,13 @@
           - requests==2.27.1
           - elasticsearch-curator==5.8.4
 
+    - name: Ensure logs directory for some cronjobs exists
+      ansible.builtin.file:
+        path: "{{ webportal_logs_dir }}"
+        state: directory
+        owner: "{{ webportal_user }}"
+        group: "{{ webportal_user }}"
+
     - name: Update hardcoded username in cron file
       ansible.builtin.replace:
         path: "{{ webportal_cron_file }}"
@@ -336,4 +343,4 @@
     - name: Add health checks cron entries to user crontab
       command: crontab -u {{ webportal_user }} {{ webportal_cron_file }}
 
-  when: webportal_setup_health_checks
+  when: webportal_setup_cron_jobs


### PR DESCRIPTION
# PULL REQUEST

## Overview

S3 backup cron job expects existing `skynet-webportal/logs` directory, which is missing by default.

This PR makes sure the `logs` directory is present.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
