### PR TITLE
Fix docker flags for portal_modules. 

### DIFF
--- a/playbooks/tasks/portal-configs-load.yml
+++ b/playbooks/tasks/portal-configs-load.yml
@@ -100,6 +100,12 @@
       {% endfor %}
   failed_when: mongodb_config_server_preference_result.failed | default(False)
 
+# If portal_modules is defined in hosts.ini, update the values
+- name: Update portal_modules
+  set_fact:
+    webportal_server_config: "{{ webportal_server_config | combine({'portal_modules': portal_modules}, recursive=True) }}"
+  when: portal_modules is defined
+
 - name: Set Accounts flag
   set_fact:
     portal_accounts_on: >-

--- a/playbooks/templates/.env.j2
+++ b/playbooks/templates/.env.j2
@@ -59,7 +59,7 @@ SIA_API_PASSWORD={{ webportal_server_config.sia_api_password }}
 # PORTAL_MODULES=aj
 #
 # REQUIRED: manually defined by user, default is mongo
-PORTAL_MODULES={{ portal_modules | default(webportal_server_config.portal_modules) }}
+PORTAL_MODULES={{ webportal_server_config.portal_modules }}
 
 # Sia wallet password
 #


### PR DESCRIPTION
…the docker flags are set

<!--
Please read and fill out this form before submitting your PR.

IMPORTANT:
Before continuing, please make sure that ALL your commits are signed!
- Setting up signing commits:
  https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
- Signing existing commits:
  https://superuser.com/a/1123928/664691
- If that doesn't work, squash your commits and force push one signed commit.
-->

# PULL REQUEST

## Overview

<!--
Provide a detailed description of the change.
-->
The way the `portal_modules` variable from `hosts.ini` was being used didn't properly set the docker flags. 

## Example for Visual Changes

<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist

<!--
Review and complete the checklist to ensure that the PR is complete before
assigned to an approver. Leave blank any that you are unsure about.
-->

- [ ] All git commits are signed. (REQUIRED)
- [ ] All new methods or updated methods have clear docstrings.
- [ ] Testing added or updated for new methods.
- [ ] Verified if any changes impact the WebPortal Health Checks.
- [ ] Appropriate documentation updated.
- [ ] Changelog file created.

## Issues Closed

<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
Closes SKY-786