### PR TITLE
Fix bug with empty portal_modules in lastpass

### DIFF
--- a/playbooks/portals-run-health-checks.yml
+++ b/playbooks/portals-run-health-checks.yml
@@ -1,4 +1,4 @@
-- name: Run integration tests against Skynet Webportals
+- name: Run Health Checks against Skynet Webportals
   hosts: webportals
   remote_user: "{{ webportal_user }}"
   gather_facts: False
@@ -14,7 +14,6 @@
     max_hosts: "{{ groups['webportals'] | length - 1 }}"
 
   tasks:
-
     # Check '--limit' is used
     - name: Fail if you are targeting all dev and prod webportals
       include_tasks: tasks/host-limit-check.yml

--- a/playbooks/tasks/portal-configs-load.yml
+++ b/playbooks/tasks/portal-configs-load.yml
@@ -3,11 +3,8 @@
 # - Load portal configs from secrets backend (e.g. LastPass)
 # - Set default values (for unset keys)
 # - Set mongodb mgkey (if defined but empty)
-# - Set mongodb flag
+# - Set portal modules flag
 # - Set mongodb config (if mongodb is on)
-# - Set accounts flag
-# - Set blocker flag
-# - Set abuse flag
 
 - name: Include loading portal config
   include_tasks: "{{ playbook_dir }}/{{ load_portal_config_handler }}"
@@ -119,12 +116,11 @@
     - portal_modules is defined
     - webportal_server_config.portal_modules is defined
 
-- name: Set Accounts flag
-  set_fact:
-    portal_accounts_on: >-
-      {{ webportal_server_config.portal_modules is defined and
-      webportal_server_config.portal_modules is not none and
-      'a' in webportal_server_config.portal_modules }}
+# Set portal module flags
+- name: Set Portal Module Flags from hosts.ini
+  include_tasks: tasks/portal-set-module-flags.yml
+  vars:
+    portal_modules_string: "{{ portal_modules | default(webportal_server_config.portal_modules) }}"
 
 # Portal is anonymous if Accounts are off or if Accounts are on and
 # accounts_limit_access is set to 'false' (case insensitive).
@@ -138,31 +134,3 @@
       {{ not portal_accounts_on
       or webportal_common_config.accounts_limit_access
       | default("authenticated") | string | lower == 'false' }}
-
-- name: Set Blocker flag
-  set_fact:
-    portal_blocker_on: >-
-      {{ webportal_server_config.portal_modules is defined and
-      webportal_server_config.portal_modules is not none and
-      'b' in webportal_server_config.portal_modules }}
-
-- name: Set Abuse Scanner flag
-  set_fact:
-    portal_abuse_scanner_on: >-
-      {{ webportal_server_config.portal_modules is defined and
-      webportal_server_config.portal_modules is not none and
-      'u' in webportal_server_config.portal_modules }}
-
-- name: Set Jaeger flag
-  set_fact:
-    portal_jaeger_on: >-
-      {{ webportal_server_config.portal_modules is defined and
-      webportal_server_config.portal_modules is not none and
-      'j' in webportal_server_config.portal_modules }}
-
-- name: Set Pinner flag
-  set_fact:
-    portal_pinner_on: >-
-      {{ webportal_server_config.portal_modules is defined and
-      webportal_server_config.portal_modules is not none and
-      'p' in webportal_server_config.portal_modules }}

--- a/playbooks/tasks/portal-deploy-enable-loadbalancer.yml
+++ b/playbooks/tasks/portal-deploy-enable-loadbalancer.yml
@@ -1,5 +1,7 @@
 ---
 # Deploy Portal to Server Part 2: Run Tests and Enable Loadbalancer
+- name: Sleep for 10min to give server time to level out before running tests
+  ansible.builtin.command: sleep 600
 
 - name: Include running portal integration tests
   include_tasks: tasks/portal-integration-tests-run.yml

--- a/playbooks/tasks/portal-health-checks-run.yml
+++ b/playbooks/tasks/portal-health-checks-run.yml
@@ -20,6 +20,8 @@
   # Retry 5 times with 1 minute in between
   delay: 60
   retries: 5
+  register: test_result
+  until: test_result.rc == 0
 
 # Run extended health checks
 - name: Run extended health checks
@@ -28,3 +30,5 @@
   # Retry 5 times with 1 minute in between
   delay: 60
   retries: 5
+  register: test_result
+  until: test_result.rc == 0

--- a/playbooks/tasks/portal-integration-tests-run.yml
+++ b/playbooks/tasks/portal-integration-tests-run.yml
@@ -6,3 +6,5 @@
   # Retry 5 times with 1 minute in between
   delay: 60
   retries: 5
+  register: test_result
+  until: test_result.rc == 0

--- a/playbooks/tasks/portal-set-module-flags.yml
+++ b/playbooks/tasks/portal-set-module-flags.yml
@@ -1,0 +1,32 @@
+---
+# Set portal module flags
+
+# Fail if portal modules are not defined or are none
+- name: Fail if portal modules are not defined or are none
+  fail:
+    msg: |
+      Portal modules must be defined.
+      Please define them in your hosts.ini file.
+  failed_when:
+    - portal_modules_string is not defined
+    - portal_modules_string is none
+
+- name: Set Accounts flag
+  set_fact:
+    portal_accounts_on: "{{ 'a' in portal_modules_string }}"
+
+- name: Set Blocker flag
+  set_fact:
+    portal_blocker_on: "{{ 'b' in portal_modules_string }}"
+
+- name: Set Abuse Scanner flag
+  set_fact:
+    portal_abuse_scanner_on: "{{ 'u' in portal_modules_string }}"
+
+- name: Set Jaeger flag
+  set_fact:
+    portal_jaeger_on: "{{ 'j' in portal_modules_string }}"
+
+- name: Set Pinner flag
+  set_fact:
+    portal_pinner_on: "{{ 'p' in portal_modules_string }}"


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

IMPORTANT:
Before continuing, please make sure that ALL your commits are signed!
- Setting up signing commits:
  https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
- Signing existing commits:
  https://superuser.com/a/1123928/664691
- If that doesn't work, squash your commits and force push one signed commit.
-->

# PULL REQUEST

## Overview
portal_modules updated didn't handle empty lastpass values correctly since the flags were still being set off of the webportal config values. 

refactored and fixed for clarity. 

Add sleep back in before running tests and enabling the server.

Fix retries for the tests as they weren't actually triggering. oops. 

<!--
Provide a detailed description of the change.
-->

## Example for Visual Changes

<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist

<!--
Review and complete the checklist to ensure that the PR is complete before
assigned to an approver. Leave blank any that you are unsure about.
-->

- [ ] All git commits are signed. (REQUIRED)
- [ ] All new methods or updated methods have clear docstrings.
- [ ] Testing added or updated for new methods.
- [ ] Verified if any changes impact the WebPortal Health Checks.
- [ ] Appropriate documentation updated.
- [ ] Changelog file created.

## Issues Closed

<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
