### PR TITLE
Fix deprecated portal_modules message in LastPass server configs

### DIFF
--- a/playbooks/tasks/portal-configs-load.yml
+++ b/playbooks/tasks/portal-configs-load.yml
@@ -111,7 +111,7 @@
 # overwritten
 - name: Update portal_modules
   set_fact:
-    webportal_server_config: "{{ webportal_server_config | combine({'portal_modules': 'DEPRECATED: update value in hosts.ini'}) }}"
+    webportal_server_config: "{{ webportal_server_config | combine({'portal_modules': 'DEPRECATED - update value in hosts.ini'}) }}"
   when:
     - portal_modules is defined
     - webportal_server_config.portal_modules is defined


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

IMPORTANT:
Before continuing, please make sure that ALL your commits are signed!
- Setting up signing commits:
  https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
- Signing existing commits:
  https://superuser.com/a/1123928/664691
- If that doesn't work, squash your commits and force push one signed commit.
-->

# PULL REQUEST

## Overview

Recent update to add `DEPRECATED: ...` message containing colon (`:`) to `portal_modules` in LastPass server configs broke the yaml syntax and server configs can't be loaded from LastPass anymore if the portal modules are defined in `hosts.ini` and the message is kept in LastPass. This PR fixes the message.

<!--
Provide a detailed description of the change.
-->

## Example for Visual Changes

<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist

<!--
Review and complete the checklist to ensure that the PR is complete before
assigned to an approver. Leave blank any that you are unsure about.
-->

- [x] All git commits are signed. (REQUIRED)
- [x] All new methods or updated methods have clear docstrings.
- [x] Testing added or updated for new methods.
- [x] Verified if any changes impact the WebPortal Health Checks.
- [x] Appropriate documentation updated.
- [ ] Changelog file created.

## Issues Closed

<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
