### PR TITLE
clean up integration tests command

### DIFF
--- a/playbooks/tasks/portal-integration-tests-run.yml
+++ b/playbooks/tasks/portal-integration-tests-run.yml
@@ -2,7 +2,7 @@
 # Run integration tests against webportal
 
 - name: Run integration tests
-  ansible.builtin.command: "docker run --rm --env-file {{ webportal_dir }}/.env node:alpine sh -c 'apk add git && git clone https://github.com/SkynetLabs/skynet-js.git && cd skynet-js && yarn && SKYNET_JS_INTEGRATION_TEST_SERVER=https://${SERVER_DOMAIN:-${PORTAL_DOMAIN}} SKYNET_JS_INTEGRATION_TEST_SKYNET_API_KEY=${ACCOUNTS_TEST_USER_API_KEY} yarn jest integration'"
+  ansible.builtin.command: "docker run --rm --env-file {{ webportal_dir }}/.env node:lts-alpine sh -c 'apk add --no-cache git && git clone https://github.com/SkynetLabs/skynet-js.git --single-branch --depth 1 && cd skynet-js && yarn --frozen-lockfile && SKYNET_JS_INTEGRATION_TEST_SERVER=https://${SERVER_DOMAIN:-${PORTAL_DOMAIN}} SKYNET_JS_INTEGRATION_TEST_SKYNET_API_KEY=${ACCOUNTS_TEST_USER_API_KEY} yarn jest integration'"
   # Retry 5 times with 1 minute in between
   delay: 60
   retries: 5

--- a/playbooks/tasks/portal-integration-tests-run.yml
+++ b/playbooks/tasks/portal-integration-tests-run.yml
@@ -2,7 +2,16 @@
 # Run integration tests against webportal
 
 - name: Run integration tests
-  ansible.builtin.command: "docker run --rm --env-file {{ webportal_dir }}/.env node:lts-alpine sh -c 'apk add --no-cache git && git clone https://github.com/SkynetLabs/skynet-js.git --single-branch --depth 1 && cd skynet-js && yarn --frozen-lockfile && SKYNET_JS_INTEGRATION_TEST_SERVER=https://${SERVER_DOMAIN:-${PORTAL_DOMAIN}} SKYNET_JS_INTEGRATION_TEST_SKYNET_API_KEY=${ACCOUNTS_TEST_USER_API_KEY} yarn jest integration'"
+  ansible.builtin.command: |
+    docker run --rm --env-file {{ webportal_dir }}/.env node:lts-alpine sh -c ' \
+      apk add --no-cache git && \
+      git clone https://github.com/SkynetLabs/skynet-js.git --single-branch --depth 1 && \
+      cd skynet-js && \
+      yarn --frozen-lockfile && \
+      SKYNET_JS_INTEGRATION_TEST_SERVER=https://${SERVER_DOMAIN:-${PORTAL_DOMAIN}} \
+      SKYNET_JS_INTEGRATION_TEST_SKYNET_API_KEY=${ACCOUNTS_TEST_USER_API_KEY} \
+      yarn jest integration \
+    '
   # Retry 5 times with 1 minute in between
   delay: 60
   retries: 5


### PR DESCRIPTION
- use node lts (long term support) release to make sure we're using skynet-js supported node version (for example current lts is 16 and latest is 18 and if node releases 19 skynet-js could break until fixed so we want to lag behind a bit)
- use `--no-cache` in `apk add` as it's recommended
- use `--single-branch --depth 1` to fetch just one branch (clones the repo faster)
- use `--frozen-lockfile` on `yarn` to make sure yarn doesn't need to check for versions during install, only installs what's in lockfile