### PR TITLE
Drop the 10 min wait before running integration tests on deploy

### DIFF
--- a/playbooks/tasks/portal-deploy-enable-loadbalancer.yml
+++ b/playbooks/tasks/portal-deploy-enable-loadbalancer.yml
@@ -1,8 +1,5 @@
 ---
 # Deploy Portal to Server Part 2: Run Tests and Enable Loadbalancer
-- name: Sleep for 10min to give server time to level out before running tests
-  ansible.builtin.command: sleep 600
-
 - name: Include running portal integration tests
   include_tasks: tasks/portal-integration-tests-run.yml
 


### PR DESCRIPTION
We should not need it any more with the fixes.