### PR TITLE
support deny_public_access as a replacement for takedown

### DIFF
--- a/playbooks/templates/.env.j2
+++ b/playbooks/templates/.env.j2
@@ -61,6 +61,14 @@ SIA_API_PASSWORD={{ webportal_server_config.sia_api_password }}
 # REQUIRED: manually defined by user, default is mongo
 PORTAL_MODULES={{ portal_modules | default(webportal_server_config.portal_modules) }}
 
+# Block external traffic on skynet apis (also disables server in health-check module)
+# Set to true if you want to block all traffic to skynet endpoints like skylink
+# download and upload, registry read and write, handshake and dnslink access etc.
+# Internal network traffic (ie. health-checks or curl requests running from this machine)
+# will still be allowed. This is useful when you don't want to allow anyone to use your
+# server as a skynet files gateway but you still want to be able to access non-skynet apis.
+DENY_PUBLIC_ACCESS={{ deny_public_access | default(False) | string | lower }}
+
 # Sia wallet password
 #
 # REQUIRED: Ansible automatically generated


### PR DESCRIPTION
Because rewriting "takedown" feature to be backwards compatible would be almost impossible, I introduced new variable that you can pass in hosts.ini that replaces takedown functionality. Takedown should become deprecated after this is merged.

Example usage in hosts.ini:

```ini
[webportals_siasky]
...
as-hk-1 ansible_host=as-hk-1.siasky.net
as-sp-1 ansible_host=as-sp-1.siasky.net
as-sp-2 ansible_host=as-sp-2.siasky.net deny_public_access=true
eu-fin-1 ansible_host=eu-fin-1.siasky.net
...
```

Once this is merged, we should rewrite our infrastructure's hosts.ini takedown into deny_public_access.