### PR TITLE
Remove ignored red error from Ansible log

### DIFF
--- a/playbooks/tasks/portal-docker-services-stop.yml
+++ b/playbooks/tasks/portal-docker-services-stop.yml
@@ -18,3 +18,7 @@
   # .env file was not yet generated (some values in docker compose files are
   # not valid)
   ignore_errors: True # noqa ignore-errors
+  # In come cases this task is expected to fail (see above comment) and it
+  # displays red ignored error in Ansible log. Adding below failed_when removes
+  # red error from the log.
+  failed_when: False


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

IMPORTANT:
Before continuing, please make sure that ALL your commits are signed!
- Setting up signing commits:
  https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
- Signing existing commits:
  https://superuser.com/a/1123928/664691
- If that doesn't work, squash your commits and force push one signed commit.
-->

# PULL REQUEST

## Overview

Stopping docker services is expected to fail in some cases (e.g. during the first execution of `portals-setup-following`) and we ignore the error, but it is logged in red color in Ansible logs, which scares portal operators.

This PR removes red error from Ansible logs.

<!--
Provide a detailed description of the change.
-->

## Example for Visual Changes

<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist

<!--
Review and complete the checklist to ensure that the PR is complete before
assigned to an approver. Leave blank any that you are unsure about.
-->

- [x] All git commits are signed. (REQUIRED)
- [x] All new methods or updated methods have clear docstrings.
- [x] Testing added or updated for new methods.
- [x] Verified if any changes impact the WebPortal Health Checks.
- [x] Appropriate documentation updated.
- [ ] Changelog file created.

## Issues Closed

<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
