### PR TITLE
Fil/sky 1327 fix jwks.json generation

### DIFF
--- a/playbooks/tasks/ansible-repo-version-get.yml
+++ b/playbooks/tasks/ansible-repo-version-get.yml
@@ -4,7 +4,7 @@
 - name: Handle recent git security update
   local_action:
     module: ansible.builtin.command
-    cmd: git config --add safe.directory /tmp/playbook
+    cmd: git config --global --add safe.directory /tmp/playbook
   run_once: True
 
 - name: Get Ansible repo branch

--- a/playbooks/tasks/ansible-repo-version-get.yml
+++ b/playbooks/tasks/ansible-repo-version-get.yml
@@ -1,6 +1,12 @@
 ---
 # Get local Ansible repo branch and commit
 
+- name: Handle recent git security update
+  local_action:
+    module: ansible.builtin.command
+    cmd: git config --add safe.directory /tmp/playbook
+  run_once: True
+
 - name: Get Ansible repo branch
   local_action:
     module: ansible.builtin.command

--- a/playbooks/tasks/portal-accounts-generate-jwks.json.yml
+++ b/playbooks/tasks/portal-accounts-generate-jwks.json.yml
@@ -8,10 +8,10 @@
 
 - name: "Generate jwks.json using {{ oathkeeper_docker_image }} image"
   local_action:
-    # We use ansible.builtin.shell instead of community.docker.docker_container
-    # because docker_container doesn't generates jwks.json correctly, it
-    # outputs 7 json strings instead of 1.
-    module: ansible.builtin.shell
+    # We use ansible.builtin.command instead of community.docker
+    # .docker_container because docker_container doesn't generates jwks.json
+    # correctly, it outputs 7 json strings instead of 1.
+    module: ansible.builtin.command
     cmd: "docker run --rm {{ oathkeeper_docker_image }} credentials generate --alg RS256"
   register: jwks_generation_result
 

--- a/playbooks/tasks/portal-accounts-generate-jwks.json.yml
+++ b/playbooks/tasks/portal-accounts-generate-jwks.json.yml
@@ -8,16 +8,11 @@
 
 - name: "Generate jwks.json using {{ oathkeeper_docker_image }} image"
   local_action:
-    module: community.docker.docker_container
-    name: jwks-config-generator
-    image: "{{ oathkeeper_docker_image }}"
-    volumes:
-      # We call another docker container from our container (docker in
-      # docker) so we need to pass docker socket
-      - /var/run/docker.sock:/var/run/docker.sock
-    command: "credentials generate --alg RS256"
-    container_default_behavior: no_defaults
-    detach: False
+    # We use ansible.builtin.shell instead of community.docker.docker_container
+    # because docker_container doesn't generates jwks.json correctly, it
+    # outputs 7 json strings instead of 1.
+    module: ansible.builtin.shell
+    cmd: "docker run --rm {{ oathkeeper_docker_image }} credentials generate --alg RS256"
   register: jwks_generation_result
 
 - name: Remove oathkeeper container
@@ -27,4 +22,4 @@
 
 - name: Read generated jwks.json
   set_fact:
-    accounts_jwks_data: "{{ jwks_generation_result.container.Output }}"
+    accounts_jwks_data: "{{ jwks_generation_result.stdout }}"

--- a/scripts/lib/ansible-executor.sh
+++ b/scripts/lib/ansible-executor.sh
@@ -28,7 +28,7 @@ pushd $ans_dir > /dev/null
 
 # Configs
 # Current Ansible Control Machine image
-ansiblecm_image='skynetlabs/ansiblecm:ansible-3.1.0-skynetlabs-0.7.0'
+ansiblecm_image='skynetlabs/ansiblecm:ansible-3.1.0-skynetlabs-0.7.3'
 
 # To allow running 2 or more parallel ansiblecm containers running from
 # different directories (having mounted different directories) we need to


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

IMPORTANT:
Before continuing, please make sure that ALL your commits are signed!
- Setting up signing commits:
  https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
- Signing existing commits:
  https://superuser.com/a/1123928/664691
- If that doesn't work, squash your commits and force push one signed commit.
-->

# PULL REQUEST

## Overview

Fix for generating `jwks.json` using `oathkeeper` image oneliner.

There was an issue generating it using `docker_container` ansible module so it was replaced with command ansible module.
For this ansibleCM image had to be updated with installed docker package.

<!--
Provide a detailed description of the change.
-->

## Example for Visual Changes

<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist

<!--
Review and complete the checklist to ensure that the PR is complete before
assigned to an approver. Leave blank any that you are unsure about.
-->

- [x] All git commits are signed. (REQUIRED)
- [x] All new methods or updated methods have clear docstrings.
- [x] Testing added or updated for new methods.
- [x] Verified if any changes impact the WebPortal Health Checks.
- [x] Appropriate documentation updated.
- [ ] Changelog file created.

## Issues Closed

<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
