### PR TITLE
Pull `cypress` image

### DIFF
--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -311,3 +311,6 @@ renter_log_lines:
 
 # Host migrations, sync
 rsync_docker_image: "instrumentisto/rsync-ssh:alpine3.15-r0"
+
+# Abuse Scanner vars
+cypress_docker_image: "cypress/included:10.3.0"

--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -365,3 +365,10 @@
       command: crontab -u {{ webportal_user }} {{ webportal_cron_file }}
 
   when: webportal_setup_health_checks
+
+# Pull cypress image to avoid lazily pulling it on the fly when the abuse
+# scanner needs it
+- name: Pull cypress docker image
+  community.docker.docker_image:
+    name: "{{ cypress_docker_image }}"
+    source: pull

--- a/playbooks/templates/.env.j2
+++ b/playbooks/templates/.env.j2
@@ -293,11 +293,6 @@ ABUSE_PORTAL_URL={{ webportal_common_config.abuse_portal_url }}
 # REQUIRED: Hardcoded, not configurable
 ABUSE_SPONSOR="Abuse Scanner"
 
-# Temporary directory used by the abuse scanner
-#
-# OPTIONAL: manually defined by user
-ABUSE_TMP_DIR={{ webportal_common_config.abuse_tmp_dir | default('/tmp/abuse-scanner') }}
-
 # Reporting related environment variables
 #
 # OPTIONAL: manually defined by user, defaults to false

--- a/playbooks/templates/.env.j2
+++ b/playbooks/templates/.env.j2
@@ -293,6 +293,11 @@ ABUSE_PORTAL_URL={{ webportal_common_config.abuse_portal_url }}
 # REQUIRED: Hardcoded, not configurable
 ABUSE_SPONSOR="Abuse Scanner"
 
+# Temporary directory used by the abuse scanner
+#
+# OPTIONAL: manually defined by user
+ABUSE_TMP_DIR={{ webportal_common_config.abuse_tmp_dir | default('/tmp/abuse-scanner') }}
+
 # Reporting related environment variables
 #
 # OPTIONAL: manually defined by user, defaults to false


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR extends the `portal-role-task.yml` file with an extra step that pulls the `cypress` image. This avoids having to pull it on request when the abuse scanner needs it, ensuring a smooth parse of the abuse email rather than hanging for x seconds waiting on the image being pulled.

It also adds support for the `ABUSE_TMP_DIR` env. variable.

## Example for Visual Changes

N/A

## Checklist

- [x] All git commits are signed. (REQUIRED)
- [x] All new methods or updated methods have clear docstrings.
- [ ] Testing added or updated for new methods.
- [ ] Verified if any changes impact the WebPortal Health Checks.
- [ ] Appropriate documentation updated.
- [ ] Changelog file created.

## Issues Closed

Closes SKY-730