### PR TITLE
use variable to store skynet-js node image version

### DIFF
--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -333,7 +333,7 @@ webportal_other_config_files:
 skynet_js_org_and_repo: "SkynetLabs/skynet-js"
 skynet_js_repo_url: "https://github.com/{{ skynet_js_org_and_repo }}.git"
 skynet_js_repo_api_url: "https://api.github.com/repos/{{ skynet_js_org_and_repo }}"
-skynet_js_docker_test_image: "node:lts-alpine"
+skynet_js_docker_test_image: "node:18-alpine"
 
 # skynet-accounts vars
 oathkeeper_docker_image: "oryd/oathkeeper:v0.39"

--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -333,7 +333,7 @@ webportal_other_config_files:
 skynet_js_org_and_repo: "SkynetLabs/skynet-js"
 skynet_js_repo_url: "https://github.com/{{ skynet_js_org_and_repo }}.git"
 skynet_js_repo_api_url: "https://api.github.com/repos/{{ skynet_js_org_and_repo }}"
-skynet_js_docker_test_image: "node:14-buster-slim"
+skynet_js_docker_test_image: "node:lts-alpine"
 
 # skynet-accounts vars
 oathkeeper_docker_image: "oryd/oathkeeper:v0.39"

--- a/playbooks/tasks/portal-integration-tests-run.yml
+++ b/playbooks/tasks/portal-integration-tests-run.yml
@@ -3,7 +3,7 @@
 
 - name: Run integration tests
   ansible.builtin.command: |
-    docker run --rm --env-file {{ webportal_dir }}/.env node:lts-alpine sh -c ' \
+    docker run --rm --env-file {{ webportal_dir }}/.env {{ skynet_js_docker_test_image }} sh -c ' \
       apk add --no-cache git && \
       git clone https://github.com/SkynetLabs/skynet-js.git --single-branch --depth 1 && \
       cd skynet-js && \


### PR DESCRIPTION
use existing `skynet_js_docker_test_image` variable to store skynet-js node image version