### PR TITLE
setup logrotate configuration for webportal services

### DIFF
--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -194,6 +194,7 @@ webportal_dir: "{{ webportal_user_home_dir }}/skynet-webportal"
 webportal_docker_dir: "{{ webportal_dir }}/docker"
 webportal_docker_data_dir: "{{ webportal_docker_dir }}/data"
 webportal_cron_file: "{{ webportal_dir }}/setup-scripts/support/crontab"
+webportal_logrotated_dir: "{{ webportal_dir }}/setup-scripts/logrotate.d"
 elasticsearch_data_data_dir: "{{ webportal_docker_data_dir }}/elasticsearch/data"
 
 # Accounts Paths

--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -366,7 +366,7 @@
     - name: Remove all skynet-webportal logrotate configs
       command: rm -f /etc/logrotate.d/skynet-webportal-*
       become: True
-      
+
     - name: Copy over new skynet-webportal logrotate configs
       command: cp {{ webportal_logrotated_dir }}/* /etc/logrotate.d/
       become: True

--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -365,9 +365,11 @@
 - block:
     - name: Remove all skynet-webportal logrotate configs
       command: rm -f /etc/logrotate.d/skynet-webportal-*
-
+      become: True
+      
     - name: Copy over new skynet-webportal logrotate configs
       command: cp {{ webportal_logrotated_dir }}/* /etc/logrotate.d/
+      become: True
       ignore_errors: True # ignore error when copying over empty or non existing directory
 
 # Pull cypress image to avoid lazily pulling it on the fly when the abuse

--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -361,6 +361,15 @@
 
   when: webportal_setup_health_checks
 
+# Setup logrotate for webportal logs
+- block:
+    - name: Remove all skynet-webportal logrotate configs
+      command: rm -f /etc/logrotate.d/skynet-webportal-*
+
+    - name: Copy over new skynet-webportal logrotate configs
+      command: cp {{ webportal_logrotated_dir }}/* /etc/logrotate.d/
+      ignore_errors: True # ignore error when copying over empty or non existing directory
+
 # Pull cypress image to avoid lazily pulling it on the fly when the abuse
 # scanner needs it
 - name: Pull cypress docker image


### PR DESCRIPTION
- removes all logrotate.d configurations prefixed with "skynet-webportal-" (prune old ones before copying over new ones)
- copy over all logrotate config files from skynet-webportal repo (ignore errors if running on old version of skynet-webportal that does not have those defined yet)