### PR TITLE
fix cp files

### DIFF
--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -368,7 +368,7 @@
       become: True
 
     - name: Copy over new skynet-webportal logrotate configs
-      command: cp {{ webportal_logrotated_dir }}/* /etc/logrotate.d/
+      command: cp -a {{ webportal_logrotated_dir }}/. /etc/logrotate.d/
       become: True
       ignore_errors: True # ignore error when copying over empty or non existing directory
 


### PR DESCRIPTION
* is being badly expanded for some reason and we end up with error, we need to use different syntax to copy over all files in directory