### PR TITLE
fix cp permissions

### DIFF
--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -368,7 +368,7 @@
       become: True
 
     - name: Copy over new skynet-webportal logrotate configs
-      command: cp -a {{ webportal_logrotated_dir }}/. /etc/logrotate.d/
+      command: cp -r {{ webportal_logrotated_dir }}/. /etc/logrotate.d/
       become: True
       ignore_errors: True # ignore error when copying over empty or non existing directory
 


### PR DESCRIPTION
there is an error when using logrotate configs that are not owned by root

> error: Ignoring skynet-webportal-nginx because the file owner is wrong (should be root or user with uid 0).
> error: Ignoring skynet-webportal-skyd because the file owner is wrong (should be root or user with uid 0).

replace -a (preserve permissions and ownership) with -r (recursive copy, copied files is owned by user that copies it, here it is root)