### PR TITLE
delete old logrotate files before copying new ones

### DIFF
--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -373,7 +373,7 @@
       file:
         state: absent
         path: "{{ item.path }}"
-      with_items: "{{ existing_logrotate.files }}"
+      loop: "{{ existing_logrotate.files }}"
       become: True
 
     - name: Check webportal logrotate config directory

--- a/playbooks/tasks/portal-role-task.yml
+++ b/playbooks/tasks/portal-role-task.yml
@@ -363,14 +363,28 @@
 
 # Setup logrotate for webportal logs
 - block:
-    - name: Remove all skynet-webportal logrotate configs
-      command: rm -f /etc/logrotate.d/skynet-webportal-*
+    - name: List all existing skynet-webportal logrotate configs
+      ansible.builtin.find:
+        paths: /etc/logrotate.d/
+        patterns: "skynet-webportal-*"
+      register: existing_logrotate
+
+    - name: Remove all existing skynet-webportal logrotate configs
+      file:
+        state: absent
+        path: "{{ item.path }}"
+      with_items: "{{ existing_logrotate.files }}"
       become: True
+
+    - name: Check webportal logrotate config directory
+      stat:
+        path: "{{ webportal_logrotated_dir }}"
+      register: logrotate_webportal_dir
 
     - name: Copy over new skynet-webportal logrotate configs
       command: cp -r {{ webportal_logrotated_dir }}/. /etc/logrotate.d/
       become: True
-      ignore_errors: True # ignore error when copying over empty or non existing directory
+      when: logrotate_webportal_dir.stat.exists and logrotate_webportal_dir.stat.isdir
 
 # Pull cypress image to avoid lazily pulling it on the fly when the abuse
 # scanner needs it


### PR DESCRIPTION
Turns out command `rm -f /etc/logrotate.d/skynet-webportal-*` did not work as expected (asterisk was evaluated against local shell) and no files were deleted and the subsequent command that copies files does not overwrite files so once files were copied, they were not updated. This pull request changes the way we delete existing logrotate config files from host to be more reliable.

✅ Tested on dev servers and already deployed with on pro/free servers.