### PR TITLE
Insufficient balance workers issue workaround

### DIFF
--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -197,6 +197,9 @@ webportal_cron_file: "{{ webportal_dir }}/setup-scripts/support/crontab"
 webportal_logrotated_dir: "{{ webportal_dir }}/setup-scripts/logrotate.d"
 elasticsearch_data_data_dir: "{{ webportal_docker_data_dir }}/elasticsearch/data"
 
+# Sia Paths
+sia_data_dir: "{{ webportal_docker_data_dir }}/sia"
+
 # Accounts Paths
 accounts_conf_dir: "{{ webportal_docker_dir }}/accounts/conf"
 accounts_jwks_path: "{{ accounts_conf_dir }}/jwks.json"

--- a/playbooks/group_vars/webportals.yml
+++ b/playbooks/group_vars/webportals.yml
@@ -300,6 +300,9 @@ webportal_config_files:
   - "docker-compose.override.yml"
   - ".env"
 
+# generic vars
+alpine_image: alpine:3.16.2
+
 # skynet-js vars
 skynet_js_org_and_repo: "SkynetLabs/skynet-js"
 skynet_js_repo_url: "https://github.com/{{ skynet_js_org_and_repo }}.git"

--- a/playbooks/tasks/portal-logs-clean-renter-log.yml
+++ b/playbooks/tasks/portal-logs-clean-renter-log.yml
@@ -22,9 +22,8 @@
     name: clean-renter-logs
     image: alpine:3.15.0
     volumes:
-      - "{{ webportal_dir }}/docker/data/sia/renter:/sia-renter"
+      - "{{ sia_data_dir }}/renter:/sia-renter"
     command: "sed -i '/{{ item }}/d' /sia-renter/renter.log"
-    container_default_behavior: no_defaults
     detach: False
     auto_remove: True
   loop: "{{ renter_log_lines }}"

--- a/playbooks/tasks/portal-logs-clean-renter-log.yml
+++ b/playbooks/tasks/portal-logs-clean-renter-log.yml
@@ -3,11 +3,6 @@
 
 # Note: This task should be performed while sia is stopped
 
-- name: Pull Alpine image
-  community.docker.docker_image:
-    name: alpine:3.15.0
-    source: pull
-
 - name: Print timestamp before cleaning renter.log
   debug:
     msg: "{{ inventory_hostname + ' renter.log cleaning start: ' + lookup('pipe','date +%Y-%m-%dT%H:%M:%S') + ' UTC' }}"
@@ -20,7 +15,7 @@
 - name: Clean renter.log file
   community.docker.docker_container:
     name: clean-renter-logs
-    image: alpine:3.15.0
+    image: "{{ alpine_image }}"
     volumes:
       - "{{ sia_data_dir }}/renter:/sia-renter"
     command: "sed -i '/{{ item }}/d' /sia-renter/renter.log"

--- a/playbooks/tasks/portal-stop.yml
+++ b/playbooks/tasks/portal-stop.yml
@@ -7,23 +7,25 @@
 - name: Include disabling portal health check
   include_tasks: tasks/portal-health-check-disable.yml
 
-- name: Check for renter accounting issues
+# NOTE: this is a first part of temporary fix for renter accounting issues - before skyd is stopped
+- name: Calculate the number of workers on cooldown due to "ephemeral account balance was insufficient" error
   shell: docker exec sia siac renter workers hsj -v | grep insufficient | wc -l
   register: insufficient_balance_workers
 
 - name: Include stopping portal docker services
   include_tasks: tasks/portal-docker-services-stop.yml
 
-- name: Delete accounts.dat when insufficient balance workers point to renter accounting issues
+# NOTE: this is a second part of temporary fix for renter accounting issues - after skyd is stopped
+- name: Delete accounts.dat when number of workers on cooldown due to accounting error is too high
   community.docker.docker_container:
-    name: clean-accounting-data
-    image: alpine:3.15.0
+    name: delete-accounting-data
+    image: "{{ alpine_image }}"
     volumes:
       - "{{ sia_data_dir }}/renter:/sia-renter"
     command: "rm /sia-renter/accounts.dat"
     detach: False
     auto_remove: True
-  when: insufficient_balance_workers.rc == 0 and insufficient_balance_workers.stdout | int > 100
+  when: insufficient_balance_workers.rc == 0 and insufficient_balance_workers.stdout | int > 100 # arbitrary number
 
 # Below are optional tasks to include via portal-version.yml file
 - name: Include cleaning sia renter.log file

--- a/playbooks/tasks/portal-stop.yml
+++ b/playbooks/tasks/portal-stop.yml
@@ -11,17 +11,18 @@
   shell: docker exec sia siac renter workers hsj -v | grep insufficient | wc -l
   register: insufficient_balance_workers
 
-- name: DEBUG - Check for renter accounting issues
-  ansible.builtin.debug:
-    var: insufficient_balance_workers
-
 - name: Include stopping portal docker services
   include_tasks: tasks/portal-docker-services-stop.yml
 
-- name: Reset accounts.dat when insufficient balance workers point to renter accounting issues
-  ansible.builtin.file:
-    path: "{{ sia_data_dir }}/renter/accounts.dat"
-    state: absent
+- name: Delete accounts.dat when insufficient balance workers point to renter accounting issues
+  community.docker.docker_container:
+    name: clean-accounting-data
+    image: alpine:3.15.0
+    volumes:
+      - "{{ sia_data_dir }}/renter:/sia-renter"
+    command: "rm /sia-renter/accounts.dat"
+    detach: False
+    auto_remove: True
   when: insufficient_balance_workers.rc == 0 and insufficient_balance_workers.stdout | int > 100
 
 # Below are optional tasks to include via portal-version.yml file

--- a/playbooks/tasks/portal-stop.yml
+++ b/playbooks/tasks/portal-stop.yml
@@ -11,12 +11,17 @@
   shell: docker exec sia siac renter workers hsj -v | grep insufficient | wc -l
   register: insufficient_balance_workers
 
+- name: DEBUG - Check for renter accounting issues
+  ansible.builtin.debug:
+    var: insufficient_balance_workers
+
 - name: Include stopping portal docker services
   include_tasks: tasks/portal-docker-services-stop.yml
 
 - name: Reset accounts.dat when insufficient balance workers point to renter accounting issues
-  command: "rm -f {{ sia_data_dir }}/renter/accounts.dat"
-  become: True
+  ansible.builtin.file:
+    path: "{{ sia_data_dir }}/renter/accounts.dat"
+    state: absent
   when: insufficient_balance_workers.rc == 0 and insufficient_balance_workers.stdout | int > 100
 
 # Below are optional tasks to include via portal-version.yml file

--- a/playbooks/tasks/portal-stop.yml
+++ b/playbooks/tasks/portal-stop.yml
@@ -7,8 +7,17 @@
 - name: Include disabling portal health check
   include_tasks: tasks/portal-health-check-disable.yml
 
+- name: Check for renter accounting issues
+  shell: docker exec sia siac renter workers hsj -v | grep insufficient | wc -l
+  register: insufficient_balance_workers
+
 - name: Include stopping portal docker services
   include_tasks: tasks/portal-docker-services-stop.yml
+
+- name: Reset accounts.dat when insufficient balance workers point to renter accounting issues
+  command: "rm -f {{ sia_data_dir }}/renter/accounts.dat"
+  become: True
+  when: insufficient_balance_workers.rc == 0 and insufficient_balance_workers.stdout | int > 100
 
 # Below are optional tasks to include via portal-version.yml file
 - name: Include cleaning sia renter.log file


### PR DESCRIPTION
Added workaround for renter accounting issue on deploy in playbooks/tasks/portal-stop.yml. When number of workers on cooldown on a server before deploy exceeds 100, after sia is down we're deleting renter/accounts.dat file (it is recreated on startup) which temporarily resolves the issue. 

Minor changes:
- created sia data directory variable "sia_data_dir"
- created a generic variable for multi purpose alpine docker image "alpine_image" (updated to latest)
- removed redundant step "Pull Alpine image" - when using an image with "community.docker.docker_container" it will be pulled anyway if its not locally available
- removed "container_default_behavior" key from "community.docker.docker_container" usage since "no_defaults" is the default anyway

✅  tested on servers with and without renter accounting issues 👍  